### PR TITLE
Switching env based on cookies

### DIFF
--- a/ui/app/src/hooks/useCore.ts
+++ b/ui/app/src/hooks/useCore.ts
@@ -4,14 +4,15 @@ import {
   createUsecases,
   createPoolFinder,
   getConfig,
+  getEnv,
+  switchEnv,
 } from "ui-core";
 
-const config = getConfig(
-  process.env.VUE_APP_DEPLOYMENT_TAG,
-  process.env.VUE_APP_SIFCHAIN_ASSET_TAG,
-  process.env.VUE_APP_ETHEREUM_ASSET_TAG,
-);
-
+switchEnv({ location: window.location });
+const { tag, sifAssetTag, ethAssetTag } = getEnv({
+  location: window.location,
+});
+const config = getConfig(tag, sifAssetTag, ethAssetTag);
 const services = createServices(config);
 const store = createStore();
 const usecases = createUsecases({ store, services });

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -11,8 +11,7 @@
     "watch": "tsc -p ./tsconfig.compile.json -w",
     "unit": "jest --coverage --projects jest-unit.config.js",
     "integration": "jest --coverage --runInBand --projects jest-integration.config.js",
-    "test": "yarn unit && yarn integration",
-    "prepare": "npm run build"
+    "test": "yarn unit && yarn integration"
   },
   "files": [
     "lib/**/*"
@@ -26,9 +25,11 @@
     "coingecko-api": "^1.0.10",
     "decimal.js-light": "^2.5.1",
     "eventemitter2": "^6.4.3",
+    "js-cookie": "^2.2.1",
     "jsbi": "^3.1.4",
     "lodash": "^4.17.20",
     "numbro": "^2.3.2",
+    "query-string": "^7.0.0",
     "reconnecting-websocket": "^4.4.0",
     "tiny-invariant": "^1.1.0",
     "toformat": "^2.0.0",
@@ -45,6 +46,7 @@
     "@openzeppelin/test-helpers": "^0.5.11",
     "@types/big.js": "^6.0.0",
     "@types/jest": "^26.0.14",
+    "@types/js-cookie": "^2.2.6",
     "@types/lodash": "^4.14.167",
     "babel-jest": "^26.5.2",
     "concurrently": "^5.3.0",

--- a/ui/core/src/config/AppCookies.ts
+++ b/ui/core/src/config/AppCookies.ts
@@ -1,0 +1,24 @@
+import Cookies from "js-cookie";
+import { SifEnv } from "./getEnv";
+export type CookieService = Pick<typeof Cookies, "set" | "get">;
+
+const COOKIE_NAME_SIF_ENV = "__sif_env";
+
+/**
+ * DSL for managing app cookies. Eventually any cookies set by the
+ * app should be set here using App types.
+ * @param service cookie service
+ * @returns app cookie manager
+ */
+export function AppCookies(service: CookieService = Cookies) {
+  return {
+    getEnv() {
+      return service.get(COOKIE_NAME_SIF_ENV);
+    },
+    setEnv(env: SifEnv) {
+      console.log({ env });
+      return service.set(COOKIE_NAME_SIF_ENV, env.toString());
+    },
+  };
+}
+export type AppCookies = ReturnType<typeof AppCookies>;

--- a/ui/core/src/config/getEnv.test.ts
+++ b/ui/core/src/config/getEnv.test.ts
@@ -1,0 +1,64 @@
+import { getEnv, SifEnv } from "./getEnv";
+
+const profiles = {
+  devnet: {
+    tag: "devnet",
+    ethAssetTag: "ethereum.devnet",
+    sifAssetTag: "sifchain.mainnet",
+  },
+  testnet: {
+    tag: "testnet",
+    ethAssetTag: "ethereum.testnet",
+    sifAssetTag: "sifchain.mainnet",
+  },
+  mainnet: {
+    tag: "mainnet",
+    ethAssetTag: "ethereum.mainnet",
+    sifAssetTag: "sifchain.mainnet",
+  },
+  localnet: {
+    tag: "localnet",
+    ethAssetTag: "ethereum.localnet",
+    sifAssetTag: "sifchain.localnet",
+  },
+};
+const cases = [
+  { hostname: "testnet.sifchain.finance", tag: "testnet" },
+  { hostname: "devnet.sifchain.finance", tag: "devnet" },
+  { hostname: "gateway.pinata.cloud", tag: "devnet" },
+  { hostname: "dex.sifchain.finance", tag: "mainnet" },
+  { hostname: "localhost", tag: "localnet" },
+];
+
+cases.forEach(({ hostname, tag }) => {
+  describe(`host is ${hostname} then use cookie > "${tag}"`, () => {
+    const tests = [
+      {
+        input: { hostname, cookie: undefined },
+        output: profiles[tag as keyof typeof profiles],
+      },
+      {
+        input: { hostname, cookie: SifEnv.MAINNET },
+        output: profiles.mainnet,
+      },
+      {
+        input: { hostname, cookie: SifEnv.DEVNET },
+        output: profiles.devnet,
+      },
+      {
+        input: { hostname, cookie: SifEnv.TESTNET },
+        output: profiles.testnet,
+      },
+    ];
+    tests.forEach(({ input: { hostname, cookie }, output }) => {
+      test(`hostname: ${hostname} + cookie: ${cookie} = ${output.tag}`, () => {
+        expect(
+          getEnv({
+            location: { hostname },
+            cookies: { getEnv: () => cookie?.toString() },
+          }),
+        ).toEqual(output);
+      });
+    });
+  });
+});

--- a/ui/core/src/config/getEnv.ts
+++ b/ui/core/src/config/getEnv.ts
@@ -1,0 +1,74 @@
+import { AppCookies } from "./AppCookies";
+
+export enum SifEnv {
+  MAINNET,
+  TESTNET,
+  DEVNET,
+  LOCALNET,
+}
+
+const envKeys = Object.values(SifEnv).filter((s) => typeof s === "number");
+
+export function isSifEnv(a: any): a is SifEnv {
+  return envKeys.includes(parseInt(a));
+}
+
+const profileLookup = {
+  [SifEnv.DEVNET]: {
+    tag: "devnet",
+    ethAssetTag: "ethereum.devnet",
+    sifAssetTag: "sifchain.mainnet",
+  },
+  [SifEnv.TESTNET]: {
+    tag: "testnet",
+    ethAssetTag: "ethereum.testnet",
+    sifAssetTag: "sifchain.mainnet",
+  },
+  [SifEnv.MAINNET]: {
+    tag: "mainnet",
+    ethAssetTag: "ethereum.mainnet",
+    sifAssetTag: "sifchain.mainnet",
+  },
+  [SifEnv.LOCALNET]: {
+    tag: "localnet",
+    ethAssetTag: "ethereum.localnet",
+    sifAssetTag: "sifchain.localnet",
+  },
+};
+
+type GetEnvArgs = {
+  location: {
+    hostname: string;
+  };
+  cookies?: Pick<AppCookies, "getEnv">;
+};
+export function getEnv({
+  location: { hostname },
+  cookies = AppCookies(),
+}: GetEnvArgs) {
+  const cookieTag = (cookies.getEnv() as unknown) as SifEnv;
+
+  if (!cookieTag) {
+    if (hostname === "dex.sifchain.finance") {
+      return profileLookup[SifEnv.MAINNET];
+    }
+    if (hostname === "testnet.sifchain.finance") {
+      return profileLookup[SifEnv.TESTNET];
+    }
+    if (
+      hostname === "devnet.sifchain.finance" ||
+      hostname === "gateway.pinata.cloud"
+    ) {
+      return profileLookup[SifEnv.DEVNET];
+    }
+    if (hostname === "localhost") {
+      return profileLookup[SifEnv.LOCALNET];
+    }
+  }
+
+  if (profileLookup[cookieTag]) {
+    return profileLookup[cookieTag];
+  }
+
+  throw new Error("Cannot render environment");
+}

--- a/ui/core/src/config/index.ts
+++ b/ui/core/src/config/index.ts
@@ -1,25 +1,25 @@
 // TODO - Conditional load or build-time tree shake
-import localnetconfig from "./config.localnet.json";
-import devnetconfig from "./config.devnet.json";
-import testnetconfig from "./config.testnet.json";
-import mainnnetconfig from "./config.mainnet.json";
+import localnetconfig from "../config.localnet.json";
+import devnetconfig from "../config.devnet.json";
+import testnetconfig from "../config.testnet.json";
+import mainnnetconfig from "../config.mainnet.json";
 
-import assetsEthereumLocalnet from "./assets.ethereum.localnet.json";
-import assetsEthereumDevnet from "./assets.ethereum.sifchain-devnet.json";
-import assetsEthereumTestnet from "./assets.ethereum.sifchain-testnet.json";
-import assetsEthereumMainnet from "./assets.ethereum.mainnet.json";
+import assetsEthereumLocalnet from "../assets.ethereum.localnet.json";
+import assetsEthereumDevnet from "../assets.ethereum.sifchain-devnet.json";
+import assetsEthereumTestnet from "../assets.ethereum.sifchain-testnet.json";
+import assetsEthereumMainnet from "../assets.ethereum.mainnet.json";
 
-import assetsSifchainLocalnet from "./assets.sifchain.localnet.json";
-import assetsSifchainMainnet from "./assets.sifchain.mainnet.json";
+import assetsSifchainLocalnet from "../assets.sifchain.localnet.json";
+import assetsSifchainMainnet from "../assets.sifchain.mainnet.json";
 
 import {
   parseConfig,
   parseAssets,
   ChainConfig,
   AssetConfig,
-} from "./utils/parseConfig";
-import { Asset } from "./entities";
-import { ServiceContext } from "./services";
+} from "../utils/parseConfig";
+import { Asset } from "../entities";
+import { ServiceContext } from "../services";
 
 type ConfigMap = { [s: string]: ServiceContext };
 type AssetMap = { [s: string]: Asset[] };

--- a/ui/core/src/config/switchEnv.test.ts
+++ b/ui/core/src/config/switchEnv.test.ts
@@ -1,0 +1,67 @@
+import { switchEnv } from "./switchEnv";
+
+it("switches the env when provided with an _env string", () => {
+  const loc = {
+    href: "/#/foo",
+    search: "?_env=1",
+  };
+  const setEnv = jest.fn();
+  switchEnv({ location: loc, cookies: { setEnv } });
+  expect(setEnv).toHaveBeenCalledWith("1");
+  expect(loc.href).toBe("/");
+});
+
+it("switches the env when provided with a second _env string", () => {
+  const loc = {
+    href: "/#/foo",
+    search: "?_env=0",
+  };
+  const setEnv = jest.fn();
+  switchEnv({ location: loc, cookies: { setEnv } });
+  expect(setEnv).toHaveBeenCalledWith("0");
+  expect(loc.href).toBe("/");
+});
+
+it("doesnt switch the env when no string is provided", () => {
+  const loc = {
+    href: "/#/foo",
+    search: "",
+  };
+  const setEnv = jest.fn();
+  switchEnv({ location: loc, cookies: { setEnv } });
+  expect(setEnv).not.toHaveBeenCalled();
+  expect(loc.href).toBe("/#/foo");
+});
+
+it("doesnt switch the env when provided with an _env string out of bounds of SifEnv", () => {
+  const loc = {
+    href: "/#/foo",
+    search: "?_env=7",
+  };
+  const setEnv = jest.fn();
+  switchEnv({ location: loc, cookies: { setEnv } });
+  expect(setEnv).not.toHaveBeenCalled();
+  expect(loc.href).toBe("/#/foo");
+});
+
+it("doesnt switch the env when provided with another _env string out of bounds of SifEnv", () => {
+  const loc = {
+    href: "/#/foo",
+    search: "?_env=-1",
+  };
+  const setEnv = jest.fn();
+  switchEnv({ location: loc, cookies: { setEnv } });
+  expect(setEnv).not.toHaveBeenCalled();
+  expect(loc.href).toBe("/#/foo");
+});
+
+it("doesnt react to garbage", () => {
+  const loc = {
+    href: "/#/foo",
+    search: "?_env=akjshdlkasjhdlkj",
+  };
+  const setEnv = jest.fn();
+  switchEnv({ location: loc, cookies: { setEnv } });
+  expect(setEnv).not.toHaveBeenCalled();
+  expect(loc.href).toBe("/#/foo");
+});

--- a/ui/core/src/config/switchEnv.ts
+++ b/ui/core/src/config/switchEnv.ts
@@ -1,0 +1,25 @@
+// Designed to be run in the browser
+import queryString from "query-string";
+import { AppCookies } from "./AppCookies";
+import { isSifEnv } from "./getEnv";
+
+export function switchEnv({
+  location = window.location,
+  cookies = AppCookies(),
+}: {
+  location: { search: string; href: string };
+  cookies?: Pick<AppCookies, "setEnv">;
+}) {
+  const parsed = queryString.parse(location.search);
+
+  const env = parsed["_env"];
+
+  if (typeof env === "undefined" || env === null || Array.isArray(env)) {
+    return;
+  }
+
+  if (isSifEnv(env)) {
+    cookies.setEnv(env);
+    location.href = "/";
+  }
+}

--- a/ui/core/src/index.ts
+++ b/ui/core/src/index.ts
@@ -5,4 +5,6 @@ export * from "./store";
 export * from "./usecases/clp/calculators";
 export * from "./usecases/clp/calculators/utils";
 export * from "./config";
+export * from "./config/getEnv";
+export * from "./config/switchEnv";
 export * from "./utils";

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -4801,6 +4801,11 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
+"@types/js-cookie@^2.2.6":
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.6.tgz#f1a1cb35aff47bc5cfb05cb0c441ca91e914c26f"
+  integrity sha512-+oY0FDTO2GYKEV0YPvSshGq9t7YozVkgvXLty7zogQNuCxBhT9/3INX9Q7H1aRZ4SUDRXAKlJuA4EA5nTt7SNw==
+
 "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
@@ -5712,7 +5717,7 @@
     "@vue/compiler-dom" "3.0.9"
     "@vue/shared" "3.0.9"
 
-"@vue/component-compiler-utils@^3.1.2":
+"@vue/component-compiler-utils@^3.1.0", "@vue/component-compiler-utils@^3.1.2":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@vue/component-compiler-utils/-/component-compiler-utils-3.2.0.tgz#8f85182ceed28e9b3c75313de669f83166d11e5d"
   integrity sha512-lejBLa7xAMsfiZfNp7Kv51zOzifnb29FwdnMLa96z26kXErPFioSf9BMcePVIQ6/Gc6/mC0UrPpxAWIHyae0vw==
@@ -11326,6 +11331,11 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+filter-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
+  integrity sha1-mzERErxsYSehbgFsbF1/GeCAXFs=
+
 finalhandler@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
@@ -14878,6 +14888,11 @@ js-beautify@^1.6.12, js-beautify@^1.6.14:
     mkdirp "^1.0.4"
     nopt "^5.0.0"
 
+js-cookie@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+
 js-message@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/js-message/-/js-message-1.0.5.tgz#2300d24b1af08e89dd095bc1a4c9c9cfcb892d15"
@@ -15614,7 +15629,7 @@ lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.21, lodash@4.x, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.7.0:
+lodash@4.x, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -18947,6 +18962,16 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.0.0.tgz#aaad2c8d5c6a6d0c6afada877fecbd56af79e609"
+  integrity sha512-Iy7moLybliR5ZgrK/1R3vjrXq03S13Vz4Rbm5Jg3EFq1LUmQppto0qtXz4vqZ386MSRjZgnTSZ9QC+NZOSd/XA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -20695,6 +20720,11 @@ spdy@^4.0.2:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -20871,6 +20901,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-hash@^1.1.1:
   version "1.1.3"
@@ -22461,7 +22496,7 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-parse@1.5.0, url-parse@^1.4.3:
+url-parse@^1.4.3:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.0.tgz#90aba6c902aeb2d80eac17b91131c27665d5d828"
   integrity sha512-9iT6N4s93SMfzunOyDPe4vo4nLcSu1yq0IQK1gURmjm8tQNlM6loiuCRrKG1hHGXfB2EWd6H4cGi7tGdaygMFw==
@@ -22761,6 +22796,11 @@ vue-eslint-parser@^7.0.0, vue-eslint-parser@^7.1.1:
     esquery "^1.0.1"
     lodash "^4.17.15"
 
+vue-hot-reload-api@^2.3.0:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz#532955cc1eb208a3d990b3a9f9a70574657e08f2"
+  integrity sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==
+
 vue-inbrowser-compiler-utils@^4.33.6:
   version "4.33.6"
   resolved "https://registry.yarnpkg.com/vue-inbrowser-compiler-utils/-/vue-inbrowser-compiler-utils-4.33.6.tgz#022353b3a4dc202e05271277cef1ef4d091ca6f2"
@@ -22805,7 +22845,18 @@ vue-jest@^5.0.0-0:
     hash-sum "^2.0.0"
     loader-utils "^2.0.0"
 
-vue-loader@^15.9.2, vue-loader@^16.1.2:
+vue-loader@^15.9.2:
+  version "15.9.7"
+  resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-15.9.7.tgz#15b05775c3e0c38407679393c2ce6df673b01044"
+  integrity sha512-qzlsbLV1HKEMf19IqCJqdNvFJRCI58WNbS6XbPqK13MrLz65es75w392MSQ5TsARAfIjUw+ATm3vlCXUJSOH9Q==
+  dependencies:
+    "@vue/component-compiler-utils" "^3.1.0"
+    hash-sum "^1.0.2"
+    loader-utils "^1.1.0"
+    vue-hot-reload-api "^2.3.0"
+    vue-style-loader "^4.1.0"
+
+vue-loader@^16.1.2:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-16.2.0.tgz#046a53308dd47e58efe20ddec1edec027ce3b46e"
   integrity sha512-TitGhqSQ61RJljMmhIGvfWzJ2zk9m1Qug049Ugml6QP3t0e95o0XJjk29roNEiPKJQBEi8Ord5hFuSuELzSp8Q==
@@ -22818,6 +22869,14 @@ vue-router@^4.0.0-0:
   version "4.0.0-beta.13"
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-4.0.0-beta.13.tgz#4611d09a9e44f231cc401ecc294a7f2dcb30e6a6"
   integrity sha512-dYv9qpHPaojQlfujViiTkPkf1Bf5RCFzkCkdVFc1cENzWJYAGJanpIHiyjyKoM4u7IDFBZMItci+U4ieaEWA8A==
+
+vue-style-loader@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/vue-style-loader/-/vue-style-loader-4.1.3.tgz#6d55863a51fa757ab24e89d9371465072aa7bc35"
+  integrity sha512-sFuh0xfbtpRlKfm39ss/ikqs9AbKCoXZBpHeVZ8Tx650o0k0q/YCM7FRvigtxpACezfq6af+a7JeqVTWvncqDg==
+  dependencies:
+    hash-sum "^1.0.2"
+    loader-utils "^1.0.2"
 
 vue-style-loader@^4.1.2:
   version "4.1.2"


### PR DESCRIPTION
Seemed like consensus was we need cookie based env switching and I can't see a way around it if we want to easily run tests against mainnet frontend from the merge to master action step - so I threw this together tonight

You can switch environment by visiting:

http://localhost:8080/?_env=0 -  MAINNET
http://localhost:8080/?_env=1 -  TESTNET
http://localhost:8080/?_env=2 -  DEVNET
http://localhost:8080/?_env=3 -  LOCALNET

This sets a cookie that controls the environment: `__sif_env`

![image](https://user-images.githubusercontent.com/1256409/120659957-34034700-c4ca-11eb-8bd3-ceb48944e7a9.png)

You can clear the environment by heading to devtools > application > cookies and nuking the cookie

Defaults are now set via hostname as detected in the browser and overrided by cookie

| host | default |
| --- | --- |
|  `testnet.sifchain.finance` | `testnet` |
|  `gateway.pinata.cloud` | `devnet` |
|  `devnet.sifchain.finance` | `devnet` |
|  `dex.sifchain.finance` | `mainnet` |
|  `localhost` | `localnet` |

I recommend setting up bookmarklets: 
|name|location|
|---|---|
| MAINNET |  `javascript:(() => window.location.href='/?_env=0')()` |
| TESTNET |  `javascript:(() => window.location.href='/?_env=1')()` |
| DEVNET |  `javascript:(() => window.location.href='/?_env=2')()` |
| LOCALNET |  `javascript:(() => window.location.href='/?_env=3')()` |