### PR TITLE
E2E stability fixes

### DIFF
--- a/ui/e2e/helpers.js
+++ b/ui/e2e/helpers.js
@@ -1,19 +1,17 @@
 import { connectPopup } from "./pages/ConnectPopup";
 import { dexHeader } from "./pages/components/DexHeader";
-import {
-  metamaskConnectPage,
-  MetamaskConnectPage,
-} from "./pages/MetamaskConnectPage";
+import { metamaskConnectPage } from "./pages/MetamaskConnectPage";
 import { keplrNotificationPopup } from "./pages/KeplrNotificationPopup";
 import urls from "./data/urls.json";
 
 export async function connectKeplrAccount() {
   // it's not necessary to invoke connectPopup.clickConnectKeplr()
-  // since keplrPage.setup() returns connect notification popup implicitly
+  // since connect popup is automatically invoked after the setup has completed
   await keplrNotificationPopup.navigate(urls.keplr.notificationPopup.connect);
   await keplrNotificationPopup.clickApprove();
   // new page opens
-  await page.waitForTimeout(1000);
+  await context.waitForEvent("page");
+
   await keplrNotificationPopup.navigate(
     urls.keplr.notificationPopup.signinApprove,
   );
@@ -22,7 +20,6 @@ export async function connectKeplrAccount() {
 
 export async function reconnectKeplrAccount() {
   await dexHeader.clickConnected();
-  await page.waitForTimeout(1000);
   const isConnected = await connectPopup.isKeplrConnected();
   if (!isConnected) await connectPopup.clickConnectKeplr();
 }
@@ -30,9 +27,11 @@ export async function reconnectKeplrAccount() {
 export async function connectMetaMaskAccount() {
   await page.bringToFront();
   await dexHeader.clickConnected();
-  await connectPopup.clickConnectMetamask();
-  // opens new page so we need to retrieve it
-  await page.waitForTimeout(4000); // TODO: replace explicit wait with dynamic waiting for page with given url
+  await connectPopup.clickConnectMetamask(); // opens new page
+
+  await context.waitForEvent("page");
+  await page.waitForTimeout(2000); // TODO: replace explicit wait with dynamic waiting for new page (which happens line above but is a bit flaky)
+
   await metamaskConnectPage.navigate();
   await metamaskConnectPage.clickNext();
   await metamaskConnectPage.clickConnect();

--- a/ui/e2e/index.test.js
+++ b/ui/e2e/index.test.js
@@ -57,9 +57,10 @@ beforeAll(async () => {
 
   // goto dex page
   await balancesPage.navigate();
-  await page.waitForTimeout(4000); // wait a second before keplr is finished being setup
 
-  // Keplr will automatically connect and cause the add chain popup to come up
+  // once keplr has finished setup, connection page will be invoked automatically
+  await context.waitForEvent("page");
+
   await connectKeplrAccount();
   await connectMetaMaskAccount();
   await page.close();

--- a/ui/e2e/pages/ConnectPopup.js
+++ b/ui/e2e/pages/ConnectPopup.js
@@ -21,10 +21,12 @@ export class ConnectPopup {
   }
 
   async isKeplrConnected() {
+    await page.waitForLoadState();
     return await page.$("text='Keplr Connected'");
   }
 
   async isMetamaskConnected() {
+    await page.waitForLoadState();
     return await page.$("text='Metamask Connected'");
   }
 

--- a/ui/e2e/pages/KeplrNotificationPopup.js
+++ b/ui/e2e/pages/KeplrNotificationPopup.js
@@ -9,6 +9,7 @@ export class KeplrNotificationPopup {
 
   async navigate(url = urls.keplr.notificationPopup.generic) {
     this.page = await getExtensionPage(this.config.id, url);
+    await this.page.waitForLoadState();
   }
 
   async clickApprove() {

--- a/ui/e2e/pages/MetamaskConnectPage.js
+++ b/ui/e2e/pages/MetamaskConnectPage.js
@@ -16,6 +16,7 @@ export class MetamaskConnectPage {
       MM_CONFIG.id,
       "/notification.html#connect",
     );
+    await this.page.waitForLoadState();
   }
 
   async clickNext() {

--- a/ui/e2e/utils.js
+++ b/ui/e2e/utils.js
@@ -46,7 +46,6 @@ export async function getExtensionPage(extensionId, suffixUrl = undefined) {
   } else {
     matchingUrl = `chrome-extension://${extensionId}${suffixUrl}`;
   }
-
   const pages = await context.pages();
   const foundPages = pages.filter((page) => page.url().includes(matchingUrl));
 


### PR DESCRIPTION
This PR introduces stability fixes, mostly by introducing additional `waitForEvent('page')` and `page.waitForLoadState()` in several places where new page is loaded