### PR TITLE
Set default tag to develop & include command to manage default tag

### DIFF
--- a/ui/scripts/latest
+++ b/ui/scripts/latest
@@ -1,1 +1,1 @@
-ghcr.io/sifchain/sifnode/ui-stack:master
+ghcr.io/sifchain/sifnode/ui-stack:develop

--- a/ui/scripts/stack.mjs
+++ b/ui/scripts/stack.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env zx
 
+import { resolve } from "path";
+
 import { dockerLoggedIn, setupStack, runStack, killStack } from "./lib.mjs";
 
 import { arg } from "./lib.mjs";
@@ -9,6 +11,7 @@ const args = arg(
     "--kill": Boolean,
     "-k": "--kill",
     "--setup-only": Boolean,
+    "--set-default-tag": String,
     "--tag": String,
     "-t": "--tag",
   },
@@ -28,11 +31,22 @@ Our docker container is built under sifchain/ui-stack which is published per com
 
 Options:
 
---tag -t       Provide an image tag to use. Usually a stable tag ie. \`develop\` or a commit hash ie. \`649e35193c8ef0730458f058d52693b1a1ca5d77\`
---kill --k     Kill any stack processes and remove all existing docker ui-stack containers 
---setup-only   This only pulls the docker stack image and extracts some build dependencies such as contract ABIs
+--tag -t            Provide an image tag to use. Usually a stable tag ie. \`develop\` or a commit hash ie. \`649e35193c8ef0730458f058d52693b1a1ca5d77\`
+--kill --k          Kill any stack processes and remove all existing docker ui-stack containers 
+--setup-only        This only pulls the docker stack image and extracts some build dependencies such as contract ABIs
+--set-default-tag   Set the default docker image tag used by the stack command. This alters the latest file on disk which needs to be checked in.
+
 `,
 );
+
+if (args["--set-default-tag"]) {
+  const tag = args["--set-default-tag"];
+  await fs.writeFile(
+    resolve(__dirname, "./latest"),
+    `ghcr.io/sifchain/sifnode/ui-stack:${tag}`,
+  );
+  process.exit(0);
+}
 
 if (args["--setup-only"]) {
   await setupStack();


### PR DESCRIPTION
After discussion with Piotr it became apparent that we should test against develop for the following reasons:
1. if we want to change the ui-stack and we are pointing to master it will take up to two weeks or more to see those changes merged to master
2. We are planning to test against master as we deploy frontend changes anyway. 

This PR also adds a `yarn stack --set-default-tag` command to make it easy to set the default image tag so we don't have to care about where the `latest` file is located and we don't have to share that information with upstream docs that might get out of date.