### PR TITLE
Tidy up defaults ensure branch failure check

### DIFF
--- a/ui/scripts/build.mjs
+++ b/ui/scripts/build.mjs
@@ -19,11 +19,14 @@ Options:
 `,
 );
 
+const noSetup = args["--no-setup"];
+const tagName = args["--tag"];
+
 const core = resolve(__dirname, "../core");
 const app = resolve(__dirname, "../app");
 
-if (!args["--no-setup"]) {
-  await setupStack(args["--tag"]);
+if (!noSetup) {
+  await setupStack(tagName);
 }
 await lint();
 await $`cd ${core} && yarn build`;

--- a/ui/scripts/e2e.mjs
+++ b/ui/scripts/e2e.mjs
@@ -30,6 +30,7 @@ Options:
 );
 
 const isDebug = args["--debug"];
+const tagName = args["--tag"] || "develop";
 
 // Only run test script
 if (isDebug) {
@@ -66,4 +67,4 @@ try {
 }
 
 // Run server and test script concurrently
-await race(serveBuiltApp(), runTests(args["--tag"]));
+await race(serveBuiltApp(), runTests(tagName));

--- a/ui/scripts/lib.mjs
+++ b/ui/scripts/lib.mjs
@@ -81,10 +81,13 @@ async function dockerImageExistsWithTag(tag) {
 
 export async function setupStack(tagName) {
   if (tagName && ["develop", "master"].includes(tagName)) {
-    const commit = await getLatestCommitForBranch(tagName);
-
-    const imageExists = await dockerImageExistsWithTag(commit);
     // Check if the latest commit in GHs develop branch matches what is in the registry
+
+    console.log("Getting latest commit...");
+    const commit = await getLatestCommitForBranch(tagName);
+    console.log("Checking latest commit exists in registry...");
+    const imageExists = await dockerImageExistsWithTag(commit);
+
     if (!imageExists) {
       console.error(
         `

--- a/ui/scripts/test.mjs
+++ b/ui/scripts/test.mjs
@@ -27,10 +27,21 @@ Options:
 `,
 );
 
-async function runCoreTests(tag, isUnit, isIntegration, isWatch, rest) {
+async function runCoreTests(
+  tag = "develop",
+  isUnit,
+  isIntegration,
+  isWatch,
+  rest,
+) {
   const core = resolve(__dirname, "../core");
 
-  await setupStack(tag);
+  // Idea here is to avoid doing any docker things when we are only running unit tests
+  if (
+    isIntegration ||
+    (typeof isIntegration === "undefined" && typeof isUnit === "undefined")
+  )
+    await setupStack(tag);
 
   // Set the env var to run against a specific tag
   if (tag) process.env.STACK_TAG = tag;
@@ -49,7 +60,7 @@ async function runCoreTests(tag, isUnit, isIntegration, isWatch, rest) {
 }
 
 await runCoreTests(
-  args["--tag"],
+  args["--tag"] || "develop",
   args["--unit"],
   args["--integration"],
   args["--watch"],


### PR DESCRIPTION
* Some tidy up.
* I realized that during running our core tests we are not checking for the correct image tag so an image build failure there would not bubble up to the frontend
* Also the playwright tests were not set to bubbleup unless the tag was set so I set it as a default