### PR TITLE
Fix bug that prevents `RewardContainer` from displaying 

### DIFF
--- a/ui/app/src/components/RewardContainer/RewardContainer.vue
+++ b/ui/app/src/components/RewardContainer/RewardContainer.vue
@@ -103,6 +103,7 @@ export default {
                 {{
                   format(data.totalClaimableCommissionsAndClaimableRewards, {
                     mantissa: 4,
+                    zeroFormat: "0",
                   }) || "0"
                 }}
               </div>
@@ -134,6 +135,7 @@ export default {
                     data.currentTotalCommissionsOnClaimableDelegatorRewards,
                     {
                       mantissa: 4,
+                      zeroFormat: "0",
                     },
                   ) || "0"
                 }}
@@ -162,7 +164,7 @@ export default {
                 {{
                   format(
                     data.claimedCommissionsAndRewardsAwaitingDispensation,
-                    { mantissa: 4 },
+                    { mantissa: 4, zeroFormat: "0" },
                   ) || "0"
                 }}
               </div>
@@ -185,7 +187,10 @@ export default {
                 class="row-amount"
                 :data-handle="claimType + '-dispensed-rewards'"
               >
-                {{ format(data.dispensed, { mantissa: 4 }) || "0" }}
+                {{
+                  format(data.dispensed, { mantissa: 4, zeroFormat: "0" }) ||
+                  "0"
+                }}
               </div>
               <AssetItem symbol="Rowan" :label="false" />
             </div>
@@ -209,6 +214,7 @@ export default {
                                 data.nextRewardProjectedAPYOnTickets * 100,
                                 {
                                   mantissa: 2,
+                                  zeroFormat: "0",
                                 },
                               )
                             }}%</span
@@ -237,6 +243,7 @@ export default {
                 {{
                   format(data.totalCommissionsAndRewardsAtMaturity, {
                     mantissa: 4,
+                    zeroFormat: "0",
                   }) || "0"
                 }}
               </div>

--- a/ui/app/src/components/shared/utils.ts
+++ b/ui/app/src/components/shared/utils.ts
@@ -1,6 +1,13 @@
 import { computed, Ref, ComputedRef } from "@vue/reactivity";
 import ColorHash from "color-hash";
-import { Asset, IAssetAmount, Network, toBaseUnits, TxHash } from "ui-core";
+import {
+  Asset,
+  IAssetAmount,
+  Network,
+  toBaseUnits,
+  TxHash,
+  Amount,
+} from "ui-core";
 import { format } from "ui-core/src/utils/format";
 import { useCore } from "@/hooks/useCore";
 
@@ -97,7 +104,14 @@ export async function getLMData(address: ComputedRef<any>, chainId: string) {
   if (!parsedData?.user) {
     return {};
   }
-  return parsedData.user;
+  return Object.fromEntries(
+    Object.entries(parsedData.user).map(([k, v]) => {
+      if (typeof v !== "number") {
+        return [k, v];
+      }
+      return [k, Amount(v.toFixed(18))];
+    }),
+  );
 }
 
 export async function getVSData(address: ComputedRef<any>, chainId: string) {
@@ -113,7 +127,14 @@ export async function getVSData(address: ComputedRef<any>, chainId: string) {
   if (!parsedData?.user) {
     return {};
   }
-  return parsedData.user;
+  return Object.fromEntries(
+    Object.entries(parsedData.user).map(([k, v]) => {
+      if (typeof v !== "number") {
+        return [k, v];
+      }
+      return [k, Amount(v.toFixed(18))];
+    }),
+  );
 }
 
 async function getClaimsData(


### PR DESCRIPTION
Summary: 
* Fixes bug that prevents a `RewardContainer` from displaying 
* adds support for decimals in scientific notation in lm/vs rewards response
* adds formatting for zeros in `RewardContainer.vue`