### PR TITLE
#36 add screenshots on failure, add describe blocks

### DIFF
--- a/.github/workflows/playwright-ui.yml
+++ b/.github/workflows/playwright-ui.yml
@@ -48,6 +48,11 @@ jobs:
         run: yarn build && yarn e2e
         env:
           CI: true
+      
+      - uses: actions/upload-artifact@master
+        with:
+          name: fe-build-artifact-${{ github.sha }}
+          path: ./e2e/screenshots
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v1

--- a/ui/e2e/.gitignore
+++ b/ui/e2e/.gitignore
@@ -1,5 +1,5 @@
 extensions
 playwright
 coverage
-screenshots
+screenshots/*
 videos

--- a/ui/e2e/CustomEnvironment.js
+++ b/ui/e2e/CustomEnvironment.js
@@ -1,0 +1,42 @@
+// import { closeAllPages, takeScreenshots } from "./utils";
+const utils = require("./utils2");
+// const takeScreenshots = require("./utils").takeScreenshots;
+// const closeAllPages = require("./utils").closeAllPages;
+const PlaywrightEnvironment = require("jest-playwright-preset/lib/PlaywrightEnvironment")
+  .default;
+
+class CustomEnvironment extends PlaywrightEnvironment {
+  async setup() {
+    await super.setup();
+  }
+
+  async teardown() {
+    await super.teardown();
+  }
+
+  async handleTestEvent(event) {
+    // await super.handleTestEvent(event);
+    switch (event.name) {
+      case "hook_failure":
+        await utils.takeScreenshots("hook_failed", this.global.context);
+        break;
+      case "test_fn_failure":
+        const parentName = event.test.parent.name.replace(/\W/g, "-");
+        const specName = event.test.name.replace(/\W/g, "-");
+
+        await utils.takeScreenshots(
+          `${parentName}-${specName}`,
+          this.global.context,
+        );
+        break;
+      case "test_done":
+        await utils.closeAllPages(this.global.context);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+module.exports = CustomEnvironment;
+// export default CustomEnvironment;

--- a/ui/e2e/CustomEnvironment.js
+++ b/ui/e2e/CustomEnvironment.js
@@ -1,7 +1,4 @@
-// import { closeAllPages, takeScreenshots } from "./utils";
-const utils = require("./utils2");
-// const takeScreenshots = require("./utils").takeScreenshots;
-// const closeAllPages = require("./utils").closeAllPages;
+const { takeScreenshots, closeAllPages } = require("./utils2");
 const PlaywrightEnvironment = require("jest-playwright-preset/lib/PlaywrightEnvironment")
   .default;
 
@@ -15,22 +12,18 @@ class CustomEnvironment extends PlaywrightEnvironment {
   }
 
   async handleTestEvent(event) {
-    // await super.handleTestEvent(event);
     switch (event.name) {
       case "hook_failure":
-        await utils.takeScreenshots("hook_failed", this.global.context);
+        await takeScreenshots("hook_failed", this.global.context);
         break;
       case "test_fn_failure":
         const parentName = event.test.parent.name.replace(/\W/g, "-");
         const specName = event.test.name.replace(/\W/g, "-");
 
-        await utils.takeScreenshots(
-          `${parentName}-${specName}`,
-          this.global.context,
-        );
+        await takeScreenshots(`${parentName}-${specName}`, this.global.context);
         break;
       case "test_done":
-        await utils.closeAllPages(this.global.context);
+        await closeAllPages(this.global.context);
         break;
       default:
         break;
@@ -39,4 +32,3 @@ class CustomEnvironment extends PlaywrightEnvironment {
 }
 
 module.exports = CustomEnvironment;
-// export default CustomEnvironment;

--- a/ui/e2e/index.test.js
+++ b/ui/e2e/index.test.js
@@ -83,401 +83,410 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  await page.close(); // TODO: move it to global teardown
+  // await page.close(); // TODO: move it to global teardown
 });
 
-it("imports rowan", async () => {
-  const assetNative = "rowan";
-  const exportAmount = "500";
-  const assetExternal = "erowan";
-  const importAmount = "100";
-  // First we need to export rowan in order to have erowan on the bridgebank contract
-  await balancesPage.navigate();
+describe("Import/export", () => {
+  it("imports rowan", async () => {
+    const assetNative = "rowan";
+    const exportAmount = "500";
+    const assetExternal = "erowan";
+    const importAmount = "100";
+    // First we need to export rowan in order to have erowan on the bridgebank contract
+    await balancesPage.navigate();
 
-  await balancesPage.openTab("native");
-  await balancesPage.export(assetNative, exportAmount);
+    await balancesPage.openTab("native");
+    await balancesPage.export(assetNative, exportAmount);
 
-  await balancesPage.openTab("external");
-  await balancesPage.verifyAssetAmount(assetExternal, "600.000000");
+    await balancesPage.openTab("external");
+    await balancesPage.verifyAssetAmount(assetExternal, "600.000000");
 
-  // Now lets import erowan
-  await balancesPage.import(assetExternal, importAmount);
+    // Now lets import erowan
+    await balancesPage.import(assetExternal, importAmount);
 
-  await balancesPage.clickConfirmImport();
+    await balancesPage.clickConfirmImport();
 
-  await page.waitForTimeout(500);
-  await metamaskNotificationPopup.navigate();
+    await page.waitForTimeout(500);
+    await metamaskNotificationPopup.navigate();
 
-  await page.waitForTimeout(1000);
-  await metamaskNotificationPopup.clickViewFullTransactionDetails();
-  await metamaskNotificationPopup.verifyTransactionDetails(
-    `${importAmount} ${assetExternal}`,
-  );
+    await page.waitForTimeout(1000);
+    await metamaskNotificationPopup.clickViewFullTransactionDetails();
+    await metamaskNotificationPopup.verifyTransactionDetails(
+      `${importAmount} ${assetExternal}`,
+    );
 
-  await metamaskNotificationPopup.clickConfirm();
-  await page.waitForTimeout(1000);
+    await metamaskNotificationPopup.clickConfirm();
+    await page.waitForTimeout(1000);
 
-  await metamaskNotificationPopup.navigate(); // this call is needed to reload this.page with a new popup page
-  await metamaskNotificationPopup.clickConfirm();
+    await metamaskNotificationPopup.navigate(); // this call is needed to reload this.page with a new popup page
+    await metamaskNotificationPopup.clickConfirm();
 
-  await page.waitForTimeout(1000);
-  await balancesPage.closeSubmissionWindow();
-  // Check that tx marker for the tx is there
-  await balancesPage.verifyTransactionPending(assetNative);
+    await page.waitForTimeout(1000);
+    await balancesPage.closeSubmissionWindow();
+    // Check that tx marker for the tx is there
+    await balancesPage.verifyTransactionPending(assetNative);
 
-  // move chain forward
-  await advanceEthBlocks(52);
+    // move chain forward
+    await advanceEthBlocks(52);
 
-  await page.waitForSelector("text=has succeded", { timeout: 60 * 1000 });
+    await page.waitForSelector("text=has succeded", { timeout: 60 * 1000 });
 
-  await balancesPage.openTab("native");
-  await balancesPage.verifyAssetAmount(assetNative, "9600.000000");
-});
-
-it("imports ether", async () => {
-  const importAmount = "1";
-  const assetExternal = "eth";
-  const assetNative = "ceth";
-
-  await balancesPage.navigate();
-
-  const cEthBalance = await getSifchainBalances(
-    keplrConfig.sifApiUrl,
-    KEPLR_CONFIG.options.address,
-    assetNative,
-  );
-
-  await balancesPage.openTab("external");
-  await balancesPage.import(assetExternal, importAmount);
-
-  await balancesPage.clickConfirmImport();
-  await page.waitForTimeout(1000);
-
-  await metamaskNotificationPopup.navigate();
-  await metamaskNotificationPopup.clickConfirm();
-
-  await page.waitForTimeout(1000);
-  await balancesPage.closeSubmissionWindow();
-
-  // Check that tx marker for the tx is there
-  await balancesPage.verifyTransactionPending(assetNative);
-
-  // move chain forward
-  await advanceEthBlocks(52);
-
-  await page.waitForSelector("text=has succeded", { timeout: 60 * 1000 });
-
-  const expectedAmount = (Number(cEthBalance) + Number(importAmount)).toFixed(
-    6,
-  );
-  await balancesPage.verifyAssetAmount(assetNative, expectedAmount);
-});
-
-it("imports tokens", async () => {
-  const importAmount = "1";
-  const importAsset = "usdc";
-  await balancesPage.navigate();
-
-  const cBalance = await getSifchainBalances(
-    keplrConfig.sifApiUrl,
-    KEPLR_CONFIG.options.address,
-    "cusdc",
-  );
-
-  await balancesPage.openTab("external");
-  await balancesPage.import(importAsset, importAmount);
-
-  await balancesPage.clickConfirmImport();
-  await page.waitForTimeout(1000);
-
-  await metamaskNotificationPopup.navigate();
-  await metamaskNotificationPopup.clickViewFullTransactionDetails();
-  await metamaskNotificationPopup.verifyTransactionDetails(
-    `${importAmount} ${importAsset}`,
-  );
-  await metamaskNotificationPopup.clickConfirm();
-  await page.waitForTimeout(1000);
-  await metamaskNotificationPopup.navigate(); // this call is needed to reload this.page with a new popup page
-  await metamaskNotificationPopup.clickConfirm();
-
-  await balancesPage.closeSubmissionWindow();
-
-  await advanceEthBlocks(52);
-
-  await page.waitForSelector("text=has succeded", { timeout: 60 * 1000 });
-
-  const expectedAmount = (Number(cBalance) + Number(importAmount)).toFixed(6);
-  await balancesPage.verifyAssetAmount("cusdc", expectedAmount);
-});
-
-it("swaps", async () => {
-  const tokenA = "cusdc";
-  const tokenB = "rowan";
-
-  await swapPage.navigate();
-
-  await swapPage.selectTokenA(tokenA);
-  await page.waitForTimeout(1000); // slowing down to avoid tokens not updating
-  await swapPage.selectTokenB(tokenB);
-
-  await swapPage.fillTokenAValue("100");
-  await swapPage.verifyTokenBValue("99.99800003");
-
-  // Check expected output (XXX: hmmm - might have to pull in formulae from core??)
-
-  await swapPage.fillTokenBValue("100");
-  await swapPage.verifyTokenAValue("100.00200005");
-
-  await swapPage.clickTokenAMax();
-  await swapPage.verifyTokenAValue("10000.0"); // TODO: trim mantissa
-  await swapPage.verifyTokenBValue("9980.0299600499");
-  await swapPage.verifyDetails({
-    expPriceMessage: "0.998003 ROWAN per cUSDC",
-    expMinimumReceived: "9880.229660 ROWAN",
-    expPriceImpact: "0.10%",
-    expLiquidityProviderFee: "9.9800 ROWAN",
+    await balancesPage.openTab("native");
+    await balancesPage.verifyAssetAmount(assetNative, "9600.000000");
   });
 
-  // Input Amount A
-  await swapPage.fillTokenAValue("50");
-  await swapPage.verifyDetails({
-    expPriceMessage: "0.999990 ROWAN per cUSDC",
-    expMinimumReceived: "49.499505 ROWAN",
-    expPriceImpact: "< 0.01%",
-    expLiquidityProviderFee: "0.00025 ROWAN",
-  });
-  await swapPage.verifyTokenBValue("49.9995000037");
+  it("imports ether", async () => {
+    const importAmount = "1";
+    const assetExternal = "eth";
+    const assetNative = "ceth";
 
-  await swapPage.clickSwap();
+    await balancesPage.navigate();
 
-  // Confirm dialog shows the expected values
-  await confirmSwapModal.verifyDetails({
-    tokenA: tokenA,
-    tokenB: tokenB,
-    expTokenAAmount: "50.000000",
-    expTokenBAmount: "49.999500",
-    expPriceMessage: "0.999990 ROWAN per cUSDC",
-    expMinimumReceived: "49.499505 ROWAN",
-    expPriceImpact: "< 0.01%",
-    expLiquidityProviderFee: "0.00025 ROWAN",
-  });
+    const cEthBalance = await getSifchainBalances(
+      keplrConfig.sifApiUrl,
+      KEPLR_CONFIG.options.address,
+      assetNative,
+    );
 
-  await confirmSwapModal.clickConfirmSwap();
+    await balancesPage.openTab("external");
+    await balancesPage.import(assetExternal, importAmount);
 
-  // Confirm transaction popup
-  await page.waitForTimeout(1000);
-  await keplrNotificationPopup.navigate();
-  await keplrNotificationPopup.clickApprove();
-  await page.waitForTimeout(10000); // wait for blockchain to update...
+    await balancesPage.clickConfirmImport();
+    await page.waitForTimeout(1000);
 
-  // Wait for balances to be the amounts expected
-  await confirmSwapModal.verifySwapMessage(
-    "Swapped 50 cUSDC for 49.9995000037 ROWAN",
-  );
+    await metamaskNotificationPopup.navigate();
+    await metamaskNotificationPopup.clickConfirm();
 
-  await confirmSwapModal.clickClose();
+    await page.waitForTimeout(1000);
+    await balancesPage.closeSubmissionWindow();
 
-  await swapPage.verifyTokenBalance(tokenA, "Balance: 9,950.00 cUSDC");
-  await swapPage.verifyTokenBalance(tokenB, "Balance: 10,050.00 ROWAN");
-});
+    // Check that tx marker for the tx is there
+    await balancesPage.verifyTransactionPending(assetNative);
 
-it("fails to swap when it can't pay gas with rowan", async () => {
-  const tokenA = "rowan";
-  const tokenB = "cusdc";
-  // Navigate to swap page
-  await swapPage.navigate();
+    // move chain forward
+    await advanceEthBlocks(52);
 
-  // Get values of token A and token B in account
-  await swapPage.selectTokenA(tokenA);
-  await page.waitForTimeout(1000); // slowing down to avoid tokens not updating
-  await swapPage.selectTokenB(tokenB);
+    await page.waitForSelector("text=has succeded", { timeout: 60 * 1000 });
 
-  await swapPage.fillTokenAValue("10000");
-  await swapPage.clickSwap();
-  await confirmSwapModal.clickConfirmSwap();
-
-  // Confirm transaction popup
-  await page.waitForTimeout(1000);
-  await keplrNotificationPopup.navigate();
-  await keplrNotificationPopup.clickApprove();
-
-  await page.waitForTimeout(10000); // wait for blockchain to update...
-
-  await expect(page).toHaveText("Transaction Failed");
-  await expect(page).toHaveText("Not enough ROWAN to cover the gas fees.");
-
-  await confirmSwapModal.closeModal();
-});
-
-it("adds liquidity", async () => {
-  const tokenA = "ceth";
-  const tokenB = "rowan";
-  await poolPage.navigate();
-
-  await poolPage.clickAddLiquidity();
-
-  await poolPage.selectTokenA(tokenA);
-  await poolPage.fillTokenAValue("10");
-  await poolPage.verifyTokenBValue("12048.19277");
-
-  await poolPage.fillTokenBValue("10000");
-  await poolPage.verifyTokenAValue("8.30000");
-
-  await poolPage.clickTokenAMax();
-  await poolPage.verifyTokenAValue("100.000000000000000000");
-  await poolPage.verifyTokenBValue("120481.92771");
-
-  expect((await poolPage.getActionsButtonText()).toUpperCase()).toBe(
-    "INSUFFICIENT FUNDS",
-  );
-
-  await poolPage.clickTokenAMax();
-  await poolPage.fillTokenAValue("5");
-  await poolPage.verifyTokenBValue("6024.09639");
-
-  expect((await poolPage.getActionsButtonText()).toUpperCase()).toBe(
-    "ADD LIQUIDITY",
-  );
-
-  await poolPage.verifyPoolPrices({
-    expForwardNumber: "0.000830",
-    expForwardSymbols: "cETH per ROWAN",
-    expBackwardNumber: "1204.819277",
-    expBackwardSymbols: "ROWAN per cETH",
+    const expectedAmount = (Number(cEthBalance) + Number(importAmount)).toFixed(
+      6,
+    );
+    await balancesPage.verifyAssetAmount(assetNative, expectedAmount);
   });
 
-  await poolPage.verifyPoolEstimates({
-    expForwardNumber: "0.000830",
-    expForwardSymbols: "CETH per ROWAN", // <-- this is a bug TODO: cETH
-    expBackwardNumber: "1204.819277",
-    expBackwardSymbols: "ROWAN per CETH", // <-- this is a bug TODO: cETH
-    expShareNumber: "0.06%",
+  it("imports tokens", async () => {
+    const importAmount = "1";
+    const importAsset = "usdc";
+    await balancesPage.navigate();
+
+    const cBalance = await getSifchainBalances(
+      keplrConfig.sifApiUrl,
+      KEPLR_CONFIG.options.address,
+      "cusdc",
+    );
+
+    await balancesPage.openTab("external");
+    await balancesPage.import(importAsset, importAmount);
+
+    await balancesPage.clickConfirmImport();
+    await page.waitForTimeout(1000);
+
+    await metamaskNotificationPopup.navigate();
+    await metamaskNotificationPopup.clickViewFullTransactionDetails();
+    await metamaskNotificationPopup.verifyTransactionDetails(
+      `${importAmount} ${importAsset}`,
+    );
+    await metamaskNotificationPopup.clickConfirm();
+    await page.waitForTimeout(1000);
+    await metamaskNotificationPopup.navigate(); // this call is needed to reload this.page with a new popup page
+    await metamaskNotificationPopup.clickConfirm();
+
+    await balancesPage.closeSubmissionWindow();
+
+    await advanceEthBlocks(52);
+
+    await page.waitForSelector("text=has succeded", { timeout: 60 * 1000 });
+
+    const expectedAmount = (Number(cBalance) + Number(importAmount)).toFixed(6);
+    await balancesPage.verifyAssetAmount("cusdc", expectedAmount);
+  });
+});
+describe("Swap", () => {
+  it("swaps", async () => {
+    const tokenA = "cusdc";
+    const tokenB = "rowan";
+
+    await swapPage.navigate();
+
+    await swapPage.selectTokenA(tokenA);
+    await page.waitForTimeout(1000); // slowing down to avoid tokens not updating
+    await swapPage.selectTokenB(tokenB);
+
+    await swapPage.fillTokenAValue("100");
+    await swapPage.verifyTokenBValue("99.99800003");
+
+    // Check expected output (XXX: hmmm - might have to pull in formulae from core??)
+
+    await swapPage.fillTokenBValue("100");
+    await swapPage.verifyTokenAValue("100.00200005");
+
+    await swapPage.clickTokenAMax();
+    await swapPage.verifyTokenAValue("10000.0"); // TODO: trim mantissa
+    await swapPage.verifyTokenBValue("9980.0299600499");
+    await swapPage.verifyDetails({
+      expPriceMessage: "0.998003 ROWAN per cUSDC",
+      expMinimumReceived: "9880.229660 ROWAN",
+      expPriceImpact: "0.10%",
+      expLiquidityProviderFee: "9.9800 ROWAN",
+    });
+
+    // Input Amount A
+    await swapPage.fillTokenAValue("50");
+    await swapPage.verifyDetails({
+      expPriceMessage: "0.999990 ROWAN per cUSDC",
+      expMinimumReceived: "49.499505 ROWAN",
+      expPriceImpact: "< 0.01%",
+      expLiquidityProviderFee: "0.00025 ROWAN",
+    });
+    await swapPage.verifyTokenBValue("49.9995000037");
+
+    await swapPage.clickSwap();
+
+    // Confirm dialog shows the expected values
+    await confirmSwapModal.verifyDetails({
+      tokenA: tokenA,
+      tokenB: tokenB,
+      expTokenAAmount: "50.000000",
+      expTokenBAmount: "49.999500",
+      expPriceMessage: "0.999990 ROWAN per cUSDC",
+      expMinimumReceived: "49.499505 ROWAN",
+      expPriceImpact: "< 0.01%",
+      expLiquidityProviderFee: "0.00025 ROWAN",
+    });
+
+    await confirmSwapModal.clickConfirmSwap();
+
+    // Confirm transaction popup
+    await page.waitForTimeout(1000);
+    await keplrNotificationPopup.navigate();
+    await keplrNotificationPopup.clickApprove();
+    await page.waitForTimeout(10000); // wait for blockchain to update...
+
+    // Wait for balances to be the amounts expected
+    await confirmSwapModal.verifySwapMessage(
+      "Swapped 50 cUSDC for 49.9995000037 ROWAN",
+    );
+
+    await confirmSwapModal.clickClose();
+
+    await swapPage.verifyTokenBalance(tokenA, "Balance: 9,950.00 cUSDC");
+    await swapPage.verifyTokenBalance(tokenB, "Balance: 10,050.00 ROWAN");
   });
 
-  // click Add Liquidity
-  await poolPage.clickActionsGo();
+  it("fails to swap when it can't pay gas with rowan", async () => {
+    const tokenA = "rowan";
+    const tokenB = "cusdc";
+    // Navigate to swap page
+    await swapPage.navigate();
 
-  expect(await confirmSupplyModal.getTitle()).toBe("You are depositing");
+    // Get values of token A and token B in account
+    await swapPage.selectTokenA(tokenA);
+    await page.waitForTimeout(1000); // slowing down to avoid tokens not updating
+    await swapPage.selectTokenB(tokenB);
 
-  expect(
-    prepareRowText(await confirmSupplyModal.getTokenInfoRowText(tokenA)),
-  ).toBe("cETH Deposited 5.000000");
+    await swapPage.fillTokenAValue("10000");
+    await swapPage.clickSwap();
+    await confirmSwapModal.clickConfirmSwap();
 
-  expect(
-    prepareRowText(await confirmSupplyModal.getTokenInfoRowText(tokenB)),
-  ).toBe("ROWAN Deposited 6024.096390");
+    // Confirm transaction popup
+    await page.waitForTimeout(1000);
+    await keplrNotificationPopup.navigate();
+    await keplrNotificationPopup.clickApprove();
 
-  expect(prepareRowText(await confirmSupplyModal.getRatesBPerARowText())).toBe(
-    "Rates 1 cETH = 1204.81927711 ROWAN",
-  );
-  expect(prepareRowText(await confirmSupplyModal.getRatesAPerBRowText())).toBe(
-    "1 ROWAN = 0.00083000 cETH",
-  );
-  expect(
-    prepareRowText(await confirmSupplyModal.getRatesShareOfPoolText()),
-  ).toBe("Share of Pool: 0.06%"); // TODO: remove ":"
+    await page.waitForTimeout(10000); // wait for blockchain to update...
 
-  await confirmSupplyModal.clickConfirmSupply();
+    await expect(page).toHaveText("Transaction Failed");
+    await expect(page).toHaveText("Not enough ROWAN to cover the gas fees.");
 
-  expect(await confirmSupplyModal.getConfirmationWaitText()).toBe(
-    "Supplying 5.00000 ceth and 6024.09639 rowan",
-  );
-
-  // Confirm transaction popup
-  await page.waitForTimeout(1000);
-  await keplrNotificationPopup.navigate();
-  await keplrNotificationPopup.clickApprove();
-  await page.waitForTimeout(10000); // wait for blockchain to update...
-
-  await confirmSupplyModal.closeModal();
-
-  await poolPage.clickManagePool(tokenA, tokenB);
-  expect(prepareRowText(await poolPage.getTotalPooledText(tokenA))).toBe(
-    "Total Pooled cETH: 8305.00000",
-  );
-  expect(prepareRowText(await poolPage.getTotalPooledText(tokenB))).toBe(
-    "Total Pooled ROWAN: 10006024.09639",
-  );
-  expect(prepareRowText(await poolPage.getTotalPoolShareText())).toBe(
-    "Your Pool Share (%): 0.0602",
-  );
-});
-
-it("fails to add liquidity when can't pay gas with rowan", async () => {
-  const tokenA = "cusdc";
-
-  await poolPage.navigate();
-  await poolPage.clickAddLiquidity();
-  await poolPage.selectTokenA(tokenA);
-  await poolPage.fillTokenBValue("10000");
-  await poolPage.clickActionsGo();
-  await confirmSupplyModal.clickConfirmSupply();
-
-  // Confirm transaction popup
-  await page.waitForTimeout(1000);
-  await keplrNotificationPopup.navigate();
-  await keplrNotificationPopup.clickApprove();
-  await page.waitForTimeout(10000); // wait for blockchain to update...
-
-  await expect(page).toHaveText("Transaction Failed");
-  await expect(page).toHaveText("Not enough ROWAN to cover the gas fees");
-
-  await confirmSupplyModal.closeModal();
-});
-
-it("formats long amounts in confirmation screen", async () => {
-  const tokenA = "ceth";
-
-  await poolPage.navigate();
-  await poolPage.clickAddLiquidity();
-
-  // Select ceth
-  await poolPage.selectTokenA(tokenA);
-  await poolPage.fillTokenAValue("1.00000000000000000000000000000");
-
-  await poolPage.clickActionsGo();
-
-  expect(await confirmSupplyModal.getTokenAmountText(tokenA)).toEqual(
-    "1.000000",
-  );
-});
-
-it("shows liquidity mining rewards", async () => {
-  await rewardsPage.navigate();
-  await rewardsPage.setCryptoeconRoute();
-  await page.reload();
-
-  await rewardsPage.verifyLMAmounts({
-    claimableAmountNumber: "200.0000",
-    pendingAmountNumber: "600.0000",
-    dispensedAmountNumber: "0",
-    projectedFullAmountNumber: "200000.0000",
+    await confirmSwapModal.closeModal();
   });
 });
 
-it("claims liquidity mining rewards", async () => {
-  await rewardsPage.navigate();
+describe("Liquidity pools", () => {
+  it("adds liquidity", async () => {
+    const tokenA = "ceth";
+    const tokenB = "rowan";
+    await poolPage.navigate();
 
-  await rewardsPage.setCryptoeconRoute();
-  await page.reload();
+    await poolPage.clickAddLiquidity();
 
-  await rewardsPage.clickClaim("lm");
-  await rewardsPage.verifyTx({
-    type: "lm",
-    claimableAmountNumber: "200.0000",
-    maturityDate: "10/8/2021, 12:48:43 PM",
+    await poolPage.selectTokenA(tokenA);
+    await poolPage.fillTokenAValue("10");
+    await poolPage.verifyTokenBValue("12048.19277");
+
+    await poolPage.fillTokenBValue("10000");
+    await poolPage.verifyTokenAValue("8.30000");
+
+    await poolPage.clickTokenAMax();
+    await poolPage.verifyTokenAValue("100.000000000000000000");
+    await poolPage.verifyTokenBValue("120481.92771");
+
+    expect((await poolPage.getActionsButtonText()).toUpperCase()).toBe(
+      "INSUFFICIENT FUNDS",
+    );
+
+    await poolPage.clickTokenAMax();
+    await poolPage.fillTokenAValue("5");
+    await poolPage.verifyTokenBValue("6024.09639");
+
+    expect((await poolPage.getActionsButtonText()).toUpperCase()).toBe(
+      "ADD LIQUIDITY",
+    );
+
+    await poolPage.verifyPoolPrices({
+      expForwardNumber: "0.000830",
+      expForwardSymbols: "cETH per ROWAN",
+      expBackwardNumber: "1204.819277",
+      expBackwardSymbols: "ROWAN per cETH",
+    });
+
+    await poolPage.verifyPoolEstimates({
+      expForwardNumber: "0.000830",
+      expForwardSymbols: "CETH per ROWAN", // <-- this is a bug TODO: cETH
+      expBackwardNumber: "1204.819277",
+      expBackwardSymbols: "ROWAN per CETH", // <-- this is a bug TODO: cETH
+      expShareNumber: "0.06%",
+    });
+
+    // click Add Liquidity
+    await poolPage.clickActionsGo();
+
+    expect(await confirmSupplyModal.getTitle()).toBe("You are depositing");
+
+    expect(
+      prepareRowText(await confirmSupplyModal.getTokenInfoRowText(tokenA)),
+    ).toBe("cETH Deposited 5.000000");
+
+    expect(
+      prepareRowText(await confirmSupplyModal.getTokenInfoRowText(tokenB)),
+    ).toBe("ROWAN Deposited 6024.096390");
+
+    expect(
+      prepareRowText(await confirmSupplyModal.getRatesBPerARowText()),
+    ).toBe("Rates 1 cETH = 1204.81927711 ROWAN");
+    expect(
+      prepareRowText(await confirmSupplyModal.getRatesAPerBRowText()),
+    ).toBe("1 ROWAN = 0.00083000 cETH");
+    expect(
+      prepareRowText(await confirmSupplyModal.getRatesShareOfPoolText()),
+    ).toBe("Share of Pool: 0.06%"); // TODO: remove ":"
+
+    await confirmSupplyModal.clickConfirmSupply();
+
+    expect(await confirmSupplyModal.getConfirmationWaitText()).toBe(
+      "Supplying 5.00000 ceth and 6024.09639 rowan",
+    );
+
+    // Confirm transaction popup
+    await page.waitForTimeout(1000);
+    await keplrNotificationPopup.navigate();
+    await keplrNotificationPopup.clickApprove();
+    await page.waitForTimeout(10000); // wait for blockchain to update...
+
+    await confirmSupplyModal.closeModal();
+
+    await poolPage.clickManagePool(tokenA, tokenB);
+    expect(prepareRowText(await poolPage.getTotalPooledText(tokenA))).toBe(
+      "Total Pooled cETH: 8305.00000",
+    );
+    expect(prepareRowText(await poolPage.getTotalPooledText(tokenB))).toBe(
+      "Total Pooled ROWAN: 10006024.09639",
+    );
+    expect(prepareRowText(await poolPage.getTotalPoolShareText())).toBe(
+      "Your Pool Share (%): 0.0602",
+    );
   });
 
-  await rewardsPage.clickClaimOnConfirmation();
-  await rewardsPage.setGetClaimsRoute();
-  // popup
-  await page.waitForTimeout(1000);
-  await keplrNotificationPopup.navigate();
-  await keplrNotificationPopup.clickApprove();
-  await page.waitForTimeout(10000); // wait for blockchain to update...
-  await rewardsPage.closeModal();
-  // should be pending claim now
-  await rewardsPage.verifyPendingClaim("lm");
+  it("fails to add liquidity when can't pay gas with rowan", async () => {
+    const tokenA = "cusdc";
+
+    await poolPage.navigate();
+    await poolPage.clickAddLiquidity();
+    await poolPage.selectTokenA(tokenA);
+    await poolPage.fillTokenBValue("10000");
+    await poolPage.clickActionsGo();
+    await confirmSupplyModal.clickConfirmSupply();
+
+    // Confirm transaction popup
+    await page.waitForTimeout(1000);
+    await keplrNotificationPopup.navigate();
+    await keplrNotificationPopup.clickApprove();
+    await page.waitForTimeout(10000); // wait for blockchain to update...
+
+    await expect(page).toHaveText("Transaction Failed");
+    await expect(page).toHaveText("Not enough ROWAN to cover the gas fees");
+
+    await confirmSupplyModal.closeModal();
+  });
+});
+
+describe("Precision handling", () => {
+  it("formats long amounts in confirmation screen", async () => {
+    const tokenA = "ceth";
+
+    await poolPage.navigate();
+    await poolPage.clickAddLiquidity();
+
+    // Select ceth
+    await poolPage.selectTokenA(tokenA);
+    await poolPage.fillTokenAValue("1.00000000000000000000000000000");
+
+    await poolPage.clickActionsGo();
+
+    expect(await confirmSupplyModal.getTokenAmountText(tokenA)).toEqual(
+      "1.000000",
+    );
+  });
+});
+
+describe("Liquidity mining", () => {
+  it("shows liquidity mining rewards", async () => {
+    await rewardsPage.navigate();
+    await rewardsPage.setCryptoeconRoute();
+    await page.reload();
+
+    await rewardsPage.verifyLMAmounts({
+      claimableAmountNumber: "200.0000",
+      pendingAmountNumber: "600.0000",
+      dispensedAmountNumber: "0",
+      projectedFullAmountNumber: "200000.0000",
+    });
+  });
+
+  it("claims liquidity mining rewards", async () => {
+    await rewardsPage.navigate();
+
+    await rewardsPage.setCryptoeconRoute();
+    await page.reload();
+
+    await rewardsPage.clickClaim("lm");
+    await rewardsPage.verifyTx({
+      type: "lm",
+      claimableAmountNumber: "200.0000",
+      maturityDate: "10/8/2021, 12:48:43 PM",
+    });
+
+    await rewardsPage.clickClaimOnConfirmation();
+    await rewardsPage.setGetClaimsRoute();
+    // popup
+    await page.waitForTimeout(1000);
+    await keplrNotificationPopup.navigate();
+    await keplrNotificationPopup.clickApprove();
+    await page.waitForTimeout(10000); // wait for blockchain to update...
+    await rewardsPage.closeModal();
+    // should be pending claim now
+    await rewardsPage.verifyPendingClaim("lm");
+  });
 });
 
 function prepareRowText(row) {

--- a/ui/e2e/jest.config.js
+++ b/ui/e2e/jest.config.js
@@ -7,4 +7,6 @@ module.exports = {
   coveragePathIgnorePatterns: ["e2e/utils.js"],
   bail: true,
   setupFilesAfterEnv: ["expect-playwright", "./setup.js"],
+  testEnvironment: "./CustomEnvironment.js",
+  testRunner: "jest-circus/runner",
 };

--- a/ui/e2e/package.json
+++ b/ui/e2e/package.json
@@ -14,6 +14,7 @@
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-jest-playwright": "^0.3.2",
     "jest": "^26.6.3",
+    "jest-circus": "^27.0.4",
     "jest-playwright-preset": "^1.5.2",
     "mkdirp": "^1.0.4",
     "node-stream-zip": "^1.13.2",

--- a/ui/e2e/setup.js
+++ b/ui/e2e/setup.js
@@ -30,4 +30,5 @@ beforeAll(async () => {
   });
   // exposing "page" object globally
   [page] = await context.pages();
+  global.context = context; // this is needed to generate screenshots inside custom environment. 'context' is not visible there
 });

--- a/ui/e2e/utils.js
+++ b/ui/e2e/utils.js
@@ -3,8 +3,9 @@ import StreamZip from "node-stream-zip";
 import axios from "axios";
 import fs from "fs";
 import path from "path";
-import mkdirp from "mkdirp";
+// import mkdirp from "mkdirp";
 
+const mkdirp = require("mkdirp");
 const retry = require("retry-assert");
 
 // Not in use, don't have good place to get the extension zips, for now
@@ -64,7 +65,8 @@ export async function getInputValue(selector) {
 export async function assertWaitedText(
   selector,
   expectedText,
-  timeout = 30000,
+  timeout = 5000,
+  // timeout = 30000,
 ) {
   const text = await retry()
     .fn(() => page.innerText(selector))
@@ -83,28 +85,32 @@ export async function assertWaitedValue(
     .until((value) => expect(value).toBe(expectedValue));
 }
 
-export async function takeScreenshot(name) {
-  const date = new Date();
-  const year = date.getFullYear();
-  const month = date.getUTCMonth() + 1;
-  const dateOfMonth = date.getUTCDate();
-  const hour = date.getUTCHours();
-  const minute = date.getUTCMinutes();
-  const sec = date.getUTCSeconds();
-  const dateString = `${year}-${month}-${dateOfMonth}-${hour}-${minute}-${sec}`;
+// export async function takeScreenshots(name, context = global.context) {
+//   const date = new Date();
+//   const year = date.getFullYear();
+//   const month = date.getUTCMonth() + 1;
+//   const dateOfMonth = date.getUTCDate();
+//   const hour = date.getUTCHours();
+//   const minute = date.getUTCMinutes();
+//   const sec = date.getUTCSeconds();
+//   const dateString = `${year}-${month}-${dateOfMonth}-${hour}-${minute}-${sec}`;
 
-  const screenshotPath = `screenshots/${browserName}-${dateString}-${name.replace(
-    / /g,
-    "_",
-  )}`;
+//   const screenshotPath = `screenshots/${name.replace(/ /g, "_")}-${dateString}`;
 
-  await mkdirp("screenshots");
+//   await mkdirp("screenshots");
 
-  const pages = await context.pages();
-  await pages.forEach(async (page) => {
-    const title = await page.title();
-    await page.screenshot({
-      path: `${screenshotPath}_${title}.png`,
-    });
-  });
-}
+//   const pages = await context.pages();
+//   await pages.forEach(async (page) => {
+//     const title = await page.title();
+//     await page.screenshot({
+//       path: `${screenshotPath}_${title}.png`,
+//     });
+//   });
+// }
+
+// export async function closeAllPages() {
+//   const pages = await context.pages();
+//   await pages.forEach(async (page) => {
+//     await page.close();
+//   });
+// }

--- a/ui/e2e/utils.js
+++ b/ui/e2e/utils.js
@@ -3,9 +3,7 @@ import StreamZip from "node-stream-zip";
 import axios from "axios";
 import fs from "fs";
 import path from "path";
-// import mkdirp from "mkdirp";
 
-const mkdirp = require("mkdirp");
 const retry = require("retry-assert");
 
 // Not in use, don't have good place to get the extension zips, for now
@@ -65,8 +63,7 @@ export async function getInputValue(selector) {
 export async function assertWaitedText(
   selector,
   expectedText,
-  timeout = 5000,
-  // timeout = 30000,
+  timeout = 30000,
 ) {
   const text = await retry()
     .fn(() => page.innerText(selector))

--- a/ui/e2e/utils.js
+++ b/ui/e2e/utils.js
@@ -84,33 +84,3 @@ export async function assertWaitedValue(
     .withTimeout(timeout)
     .until((value) => expect(value).toBe(expectedValue));
 }
-
-// export async function takeScreenshots(name, context = global.context) {
-//   const date = new Date();
-//   const year = date.getFullYear();
-//   const month = date.getUTCMonth() + 1;
-//   const dateOfMonth = date.getUTCDate();
-//   const hour = date.getUTCHours();
-//   const minute = date.getUTCMinutes();
-//   const sec = date.getUTCSeconds();
-//   const dateString = `${year}-${month}-${dateOfMonth}-${hour}-${minute}-${sec}`;
-
-//   const screenshotPath = `screenshots/${name.replace(/ /g, "_")}-${dateString}`;
-
-//   await mkdirp("screenshots");
-
-//   const pages = await context.pages();
-//   await pages.forEach(async (page) => {
-//     const title = await page.title();
-//     await page.screenshot({
-//       path: `${screenshotPath}_${title}.png`,
-//     });
-//   });
-// }
-
-// export async function closeAllPages() {
-//   const pages = await context.pages();
-//   await pages.forEach(async (page) => {
-//     await page.close();
-//   });
-// }

--- a/ui/e2e/utils2.js
+++ b/ui/e2e/utils2.js
@@ -1,0 +1,43 @@
+const mkdirp = require("mkdirp");
+
+async function takeScreenshots(name, context) {
+  if (context) {
+    const date = new Date();
+    const year = date.getFullYear();
+    const month = date.getUTCMonth() + 1;
+    const dateOfMonth = date.getUTCDate();
+    const hour = date.getUTCHours();
+    const minute = date.getUTCMinutes();
+    const sec = date.getUTCSeconds();
+    const dateString = `${year}-${month}-${dateOfMonth}-${hour}-${minute}-${sec}`;
+
+    const screenshotPath = `screenshots/${name.replace(
+      / /g,
+      "_",
+    )}-${dateString}`;
+
+    await mkdirp("screenshots");
+
+    const pages = await context.pages();
+    await pages.forEach(async (page, index) => {
+      const title = await page.title();
+      await page.screenshot({
+        path: `${screenshotPath}_${title}_${index}.png`,
+      });
+    });
+  }
+}
+
+async function closeAllPages(context) {
+  if (context) {
+    const pages = await context.pages();
+    await pages.forEach(async (page) => {
+      await page.close();
+    });
+  }
+}
+
+module.exports = {
+  takeScreenshots,
+  closeAllPages,
+};

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -23,6 +23,13 @@
   dependencies:
     "@babel/highlight" "^7.12.13"
 
+"@babel/code-frame@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.14.5.tgz#23b08d740e83f49c5e59945fbf1b43e80bbf4edb"
+  integrity sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==
+  dependencies:
+    "@babel/highlight" "^7.14.5"
+
 "@babel/compat-data@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.12.1.tgz#d7386a689aa0ddf06255005b4b991988021101a0"
@@ -32,6 +39,11 @@
   version "7.13.12"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.13.12.tgz#a8a5ccac19c200f9dd49624cac6e19d7be1236a1"
   integrity sha512-3eJJ841uKxeV8dcN/2yGEUy+RfgQspPEgQat85umsE1rotuquQ2AbIub4S6j7c50a2d+4myc+zSlnXeIHrOnhQ==
+
+"@babel/compat-data@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.14.5.tgz#8ef4c18e58e801c5c95d3c1c0f2874a2680fadea"
+  integrity sha512-kixrYn4JwfAVPa0f2yfzc2AWti6WRRyO3XjWW5PJAvtE11qhSayrrcrEnee05KAtNaPC+EwehE8Qt1UedEVB8w==
 
 "@babel/core@7.12.9":
   version "7.12.9"
@@ -98,6 +110,27 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
+"@babel/core@^7.7.2":
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.14.6.tgz#e0814ec1a950032ff16c13a2721de39a8416fcab"
+  integrity sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/generator" "^7.14.5"
+    "@babel/helper-compilation-targets" "^7.14.5"
+    "@babel/helper-module-transforms" "^7.14.5"
+    "@babel/helpers" "^7.14.6"
+    "@babel/parser" "^7.14.6"
+    "@babel/template" "^7.14.5"
+    "@babel/traverse" "^7.14.5"
+    "@babel/types" "^7.14.5"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.1.2"
+    semver "^6.3.0"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.12.1", "@babel/generator@^7.4.0":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.1.tgz#0d70be32bdaa03d7c51c8597dda76e0df1f15468"
@@ -113,6 +146,15 @@
   integrity sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==
   dependencies:
     "@babel/types" "^7.13.0"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.14.5", "@babel/generator@^7.7.2":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.14.5.tgz#848d7b9f031caca9d0cd0af01b063f226f52d785"
+  integrity sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==
+  dependencies:
+    "@babel/types" "^7.14.5"
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
@@ -164,6 +206,16 @@
     "@babel/compat-data" "^7.13.12"
     "@babel/helper-validator-option" "^7.12.17"
     browserslist "^4.14.5"
+    semver "^6.3.0"
+
+"@babel/helper-compilation-targets@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz#7a99c5d0967911e972fe2c3411f7d5b498498ecf"
+  integrity sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==
+  dependencies:
+    "@babel/compat-data" "^7.14.5"
+    "@babel/helper-validator-option" "^7.14.5"
+    browserslist "^4.16.6"
     semver "^6.3.0"
 
 "@babel/helper-create-class-features-plugin@^7.10.5":
@@ -272,6 +324,15 @@
     "@babel/template" "^7.12.13"
     "@babel/types" "^7.12.13"
 
+"@babel/helper-function-name@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz#89e2c474972f15d8e233b52ee8c480e2cfcd50c4"
+  integrity sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.14.5"
+    "@babel/template" "^7.14.5"
+    "@babel/types" "^7.14.5"
+
 "@babel/helper-get-function-arity@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz#98c1cbea0e2332f33f9a4661b8ce1505b2c19ba2"
@@ -285,6 +346,13 @@
   integrity sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==
   dependencies:
     "@babel/types" "^7.12.13"
+
+"@babel/helper-get-function-arity@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz#25fbfa579b0937eee1f3b805ece4ce398c431815"
+  integrity sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==
+  dependencies:
+    "@babel/types" "^7.14.5"
 
 "@babel/helper-hoist-variables@^7.10.4":
   version "7.10.4"
@@ -300,6 +368,13 @@
   dependencies:
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.0"
+
+"@babel/helper-hoist-variables@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz#e0dd27c33a78e577d7c8884916a3e7ef1f7c7f8d"
+  integrity sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==
+  dependencies:
+    "@babel/types" "^7.14.5"
 
 "@babel/helper-member-expression-to-functions@^7.10.4", "@babel/helper-member-expression-to-functions@^7.10.5":
   version "7.11.0"
@@ -322,6 +397,13 @@
   dependencies:
     "@babel/types" "^7.13.12"
 
+"@babel/helper-member-expression-to-functions@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.5.tgz#d5c70e4ad13b402c95156c7a53568f504e2fb7b8"
+  integrity sha512-UxUeEYPrqH1Q/k0yRku1JE7dyfyehNwT6SVkMHvYvPDv4+uu627VXBckVj891BO8ruKBkiDoGnZf4qPDD8abDQ==
+  dependencies:
+    "@babel/types" "^7.14.5"
+
 "@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.12.1", "@babel/helper-module-imports@^7.8.3":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.1.tgz#1644c01591a15a2f084dd6d092d9430eb1d1216c"
@@ -335,6 +417,13 @@
   integrity sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==
   dependencies:
     "@babel/types" "^7.13.12"
+
+"@babel/helper-module-imports@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz#6d1a44df6a38c957aa7c312da076429f11b422f3"
+  integrity sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==
+  dependencies:
+    "@babel/types" "^7.14.5"
 
 "@babel/helper-module-transforms@^7.12.1":
   version "7.12.1"
@@ -365,6 +454,20 @@
     "@babel/traverse" "^7.13.13"
     "@babel/types" "^7.13.14"
 
+"@babel/helper-module-transforms@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz#7de42f10d789b423eb902ebd24031ca77cb1e10e"
+  integrity sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.14.5"
+    "@babel/helper-replace-supers" "^7.14.5"
+    "@babel/helper-simple-access" "^7.14.5"
+    "@babel/helper-split-export-declaration" "^7.14.5"
+    "@babel/helper-validator-identifier" "^7.14.5"
+    "@babel/template" "^7.14.5"
+    "@babel/traverse" "^7.14.5"
+    "@babel/types" "^7.14.5"
+
 "@babel/helper-optimise-call-expression@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz#50dc96413d594f995a77905905b05893cd779673"
@@ -379,6 +482,13 @@
   dependencies:
     "@babel/types" "^7.12.13"
 
+"@babel/helper-optimise-call-expression@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz#f27395a8619e0665b3f0364cddb41c25d71b499c"
+  integrity sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==
+  dependencies:
+    "@babel/types" "^7.14.5"
+
 "@babel/helper-plugin-utils@7.10.4", "@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz#2f75a831269d4f677de49986dff59927533cf375"
@@ -388,6 +498,11 @@
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz#806526ce125aed03373bc416a828321e3a6a33af"
   integrity sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==
+
+"@babel/helper-plugin-utils@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz#5ac822ce97eec46741ab70a517971e443a70c5a9"
+  integrity sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==
 
 "@babel/helper-regex@^7.10.4":
   version "7.10.5"
@@ -444,6 +559,16 @@
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.12"
 
+"@babel/helper-replace-supers@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz#0ecc0b03c41cd567b4024ea016134c28414abb94"
+  integrity sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.14.5"
+    "@babel/helper-optimise-call-expression" "^7.14.5"
+    "@babel/traverse" "^7.14.5"
+    "@babel/types" "^7.14.5"
+
 "@babel/helper-simple-access@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz#32427e5aa61547d38eb1e6eaf5fd1426fdad9136"
@@ -457,6 +582,13 @@
   integrity sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==
   dependencies:
     "@babel/types" "^7.13.12"
+
+"@babel/helper-simple-access@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz#66ea85cf53ba0b4e588ba77fc813f53abcaa41c4"
+  integrity sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==
+  dependencies:
+    "@babel/types" "^7.14.5"
 
 "@babel/helper-skip-transparent-expression-wrappers@^7.12.1":
   version "7.12.1"
@@ -479,6 +611,13 @@
   dependencies:
     "@babel/types" "^7.12.13"
 
+"@babel/helper-split-export-declaration@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz#22b23a54ef51c2b7605d851930c1976dd0bc693a"
+  integrity sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==
+  dependencies:
+    "@babel/types" "^7.14.5"
+
 "@babel/helper-validator-identifier@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
@@ -489,6 +628,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
   integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
 
+"@babel/helper-validator-identifier@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz#d0f0e277c512e0c938277faa85a3968c9a44c0e8"
+  integrity sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==
+
 "@babel/helper-validator-option@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.12.1.tgz#175567380c3e77d60ff98a54bb015fe78f2178d9"
@@ -498,6 +642,11 @@
   version "7.12.17"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz#d1fbf012e1a79b7eebbfdc6d270baaf8d9eb9831"
   integrity sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==
+
+"@babel/helper-validator-option@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
+  integrity sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
 
 "@babel/helper-wrap-function@^7.10.4":
   version "7.10.4"
@@ -537,6 +686,15 @@
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.0"
 
+"@babel/helpers@^7.14.6":
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.14.6.tgz#5b58306b95f1b47e2a0199434fa8658fa6c21635"
+  integrity sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==
+  dependencies:
+    "@babel/template" "^7.14.5"
+    "@babel/traverse" "^7.14.5"
+    "@babel/types" "^7.14.5"
+
 "@babel/highlight@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.4.tgz#7d1bdfd65753538fabe6c38596cdb76d9ac60143"
@@ -555,6 +713,15 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/highlight@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.14.5.tgz#6861a52f03966405001f6aa534a01a24d99e8cd9"
+  integrity sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.5"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
 "@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.11.5", "@babel/parser@^7.12.0", "@babel/parser@^7.12.1", "@babel/parser@^7.12.3", "@babel/parser@^7.4.3":
   version "7.12.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.3.tgz#a305415ebe7a6c7023b40b5122a0662d928334cd"
@@ -564,6 +731,11 @@
   version "7.13.13"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.13.tgz#42f03862f4aed50461e543270916b47dd501f0df"
   integrity sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==
+
+"@babel/parser@^7.14.5", "@babel/parser@^7.14.6", "@babel/parser@^7.7.2":
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.6.tgz#d85cc68ca3cac84eae384c06f032921f5227f4b2"
+  integrity sha512-oG0ej7efjEXxb4UgE+klVx+3j4MVo+A2vCzm7OUN4CLo6WhQ+vSOD2yJ8m7B+DghObxtLxt3EfgMWpq+AsWehQ==
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.13.12":
   version "7.13.12"
@@ -990,6 +1162,13 @@
   integrity sha512-cHP3u1JiUiG2LFDKbXnwVad81GvfyIOmCD6HIEId6ojrY0Drfy2q1jw7BwN7dE84+kTnBjLkXoL3IEy/3JPu2w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.12.13"
+
+"@babel/plugin-syntax-typescript@^7.7.2":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.14.5.tgz#b82c6ce471b165b5ce420cf92914d6fb46225716"
+  integrity sha512-u6OXzDaIXjEstBRRoBCQ/uKQKlbuaeE5in0RvWdA4pN6AhqxTIwUsnHPU1CFZA/amYObMsuWhYfRl3Ch90HD0Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-transform-arrow-functions@^7.12.1":
   version "7.12.1"
@@ -1805,6 +1984,15 @@
     "@babel/parser" "^7.12.13"
     "@babel/types" "^7.12.13"
 
+"@babel/template@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.14.5.tgz#a9bc9d8b33354ff6e55a9c60d1109200a68974f4"
+  integrity sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/parser" "^7.14.5"
+    "@babel/types" "^7.14.5"
+
 "@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.10.4", "@babel/traverse@^7.12.1", "@babel/traverse@^7.4.3":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.1.tgz#941395e0c5cc86d5d3e75caa095d3924526f0c1e"
@@ -1834,6 +2022,21 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.14.5", "@babel/traverse@^7.7.2":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.14.5.tgz#c111b0f58afab4fea3d3385a406f692748c59870"
+  integrity sha512-G3BiS15vevepdmFqmUc9X+64y0viZYygubAMO8SvBmKARuF6CPSZtH4Ng9vi/lrWlZFGe3FWdXNy835akH8Glg==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/generator" "^7.14.5"
+    "@babel/helper-function-name" "^7.14.5"
+    "@babel/helper-hoist-variables" "^7.14.5"
+    "@babel/helper-split-export-declaration" "^7.14.5"
+    "@babel/parser" "^7.14.5"
+    "@babel/types" "^7.14.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.11.0", "@babel/types@^7.11.5", "@babel/types@^7.12.0", "@babel/types@^7.12.1", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.0", "@babel/types@^7.4.4":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.1.tgz#e109d9ab99a8de735be287ee3d6a9947a190c4ae"
@@ -1850,6 +2053,14 @@
   dependencies:
     "@babel/helper-validator-identifier" "^7.12.11"
     lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.5.tgz#3bb997ba829a2104cedb20689c4a5b8121d383ff"
+  integrity sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.5"
     to-fast-properties "^2.0.0"
 
 "@base2/pretty-print-object@1.0.0":
@@ -2470,6 +2681,18 @@
     jest-util "^26.6.2"
     slash "^3.0.0"
 
+"@jest/console@^27.0.2":
+  version "27.0.2"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-27.0.2.tgz#b8eeff8f21ac51d224c851e1729d2630c18631e6"
+  integrity sha512-/zYigssuHLImGeMAACkjI4VLAiiJznHgAl3xnFT19iWyct2LhrH3KXOjHRmxBGTkiPLZKKAJAgaPpiU9EZ9K+w==
+  dependencies:
+    "@jest/types" "^27.0.2"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    jest-message-util "^27.0.2"
+    jest-util "^27.0.2"
+    slash "^3.0.0"
+
 "@jest/core@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/core/-/core-24.9.0.tgz#2ceccd0b93181f9c4850e74f2a9ad43d351369c4"
@@ -2558,6 +2781,16 @@
     "@types/node" "*"
     jest-mock "^26.6.2"
 
+"@jest/environment@^27.0.3":
+  version "27.0.3"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-27.0.3.tgz#68769b1dfdd213e3456169d64fbe9bd63a5fda92"
+  integrity sha512-pN9m7fbKsop5vc3FOfH8NF7CKKdRbEZzcxfIo1n2TT6ucKWLFq0P6gCJH0GpnQp036++yY9utHOxpeT1WnkWTA==
+  dependencies:
+    "@jest/fake-timers" "^27.0.3"
+    "@jest/types" "^27.0.2"
+    "@types/node" "*"
+    jest-mock "^27.0.3"
+
 "@jest/fake-timers@^24.3.0", "@jest/fake-timers@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-24.9.0.tgz#ba3e6bf0eecd09a636049896434d306636540c93"
@@ -2579,6 +2812,18 @@
     jest-mock "^26.6.2"
     jest-util "^26.6.2"
 
+"@jest/fake-timers@^27.0.3":
+  version "27.0.3"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-27.0.3.tgz#9899ba6304cc636734c74478df502e18136461dd"
+  integrity sha512-fQ+UCKRIYKvTCEOyKPnaPnomLATIhMnHC/xPZ7yT1Uldp7yMgMxoYIFidDbpSTgB79+/U+FgfoD30c6wg3IUjA==
+  dependencies:
+    "@jest/types" "^27.0.2"
+    "@sinonjs/fake-timers" "^7.0.2"
+    "@types/node" "*"
+    jest-message-util "^27.0.2"
+    jest-mock "^27.0.3"
+    jest-util "^27.0.2"
+
 "@jest/globals@^26.6.2":
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-26.6.2.tgz#5b613b78a1aa2655ae908eba638cc96a20df720a"
@@ -2587,6 +2832,15 @@
     "@jest/environment" "^26.6.2"
     "@jest/types" "^26.6.2"
     expect "^26.6.2"
+
+"@jest/globals@^27.0.3":
+  version "27.0.3"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-27.0.3.tgz#1cf8933b7791bba0b99305cbf39fd4d2e3fe4060"
+  integrity sha512-OzsIuf7uf+QalqAGbjClyezzEcLQkdZ+7PejUrZgDs+okdAK8GwRCGcYCirHvhMBBQh60Jr3NlIGbn/KBPQLEQ==
+  dependencies:
+    "@jest/environment" "^27.0.3"
+    "@jest/types" "^27.0.2"
+    expect "^27.0.2"
 
 "@jest/reporters@^24.9.0":
   version "24.9.0"
@@ -2665,6 +2919,15 @@
     graceful-fs "^4.2.4"
     source-map "^0.6.0"
 
+"@jest/source-map@^27.0.1":
+  version "27.0.1"
+  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-27.0.1.tgz#2afbf73ddbaddcb920a8e62d0238a0a9e0a8d3e4"
+  integrity sha512-yMgkF0f+6WJtDMdDYNavmqvbHtiSpwRN2U/W+6uztgfqgkq/PXdKPqjBTUF1RD/feth4rH5N3NW0T5+wIuln1A==
+  dependencies:
+    callsites "^3.0.0"
+    graceful-fs "^4.2.4"
+    source-map "^0.6.0"
+
 "@jest/test-result@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-24.9.0.tgz#11796e8aa9dbf88ea025757b3152595ad06ba0ca"
@@ -2681,6 +2944,16 @@
   dependencies:
     "@jest/console" "^26.6.2"
     "@jest/types" "^26.6.2"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    collect-v8-coverage "^1.0.0"
+
+"@jest/test-result@^27.0.2":
+  version "27.0.2"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-27.0.2.tgz#0451049e32ceb609b636004ccc27c8fa22263f10"
+  integrity sha512-gcdWwL3yP5VaIadzwQtbZyZMgpmes8ryBAJp70tuxghiA8qL4imJyZex+i+USQH2H4jeLVVszhwntgdQ97fccA==
+  dependencies:
+    "@jest/console" "^27.0.2"
+    "@jest/types" "^27.0.2"
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
 
@@ -2769,6 +3042,27 @@
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
 
+"@jest/transform@^27.0.2":
+  version "27.0.2"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-27.0.2.tgz#b073b7c589e3f4b842102468875def2bb722d6b5"
+  integrity sha512-H8sqKlgtDfVog/s9I4GG2XMbi4Ar7RBxjsKQDUhn2XHAi3NG+GoQwWMER+YfantzExbjNqQvqBHzo/G2pfTiPw==
+  dependencies:
+    "@babel/core" "^7.1.0"
+    "@jest/types" "^27.0.2"
+    babel-plugin-istanbul "^6.0.0"
+    chalk "^4.0.0"
+    convert-source-map "^1.4.0"
+    fast-json-stable-stringify "^2.0.0"
+    graceful-fs "^4.2.4"
+    jest-haste-map "^27.0.2"
+    jest-regex-util "^27.0.1"
+    jest-util "^27.0.2"
+    micromatch "^4.0.4"
+    pirates "^4.0.1"
+    slash "^3.0.0"
+    source-map "^0.6.1"
+    write-file-atomic "^3.0.0"
+
 "@jest/types@^24.3.0", "@jest/types@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.9.0.tgz#63cb26cb7500d069e5a389441a7c6ab5e909fc59"
@@ -2808,6 +3102,17 @@
     "@types/istanbul-reports" "^3.0.0"
     "@types/node" "*"
     "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
+"@jest/types@^27.0.2":
+  version "27.0.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.0.2.tgz#e153d6c46bda0f2589f0702b071f9898c7bbd37e"
+  integrity sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
 "@lerna/add@3.21.0":
@@ -3787,6 +4092,13 @@
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
   integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+
+"@sinonjs/fake-timers@^7.0.2":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz#2524eae70c4910edccf99b2f4e6efc5894aff7b5"
+  integrity sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
@@ -4960,6 +5272,11 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.2.3.tgz#ef65165aea2924c9359205bf748865b8881753c0"
   integrity sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==
 
+"@types/prettier@^2.1.5":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.3.0.tgz#2e8332cc7363f887d32ec5496b207d26ba8052bb"
+  integrity sha512-hkc1DATxFLQo4VxPDpMH1gCkPpBbpOoJ/4nhuXw4n63/0R6bCpQECj4+K226UJ4JO/eJQz+1mC2I7JsWanAdQw==
+
 "@types/pretty-hrtime@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/pretty-hrtime/-/pretty-hrtime-1.0.0.tgz#c5a2d644a135e988b2932f99737e67b3c62528d0"
@@ -5155,6 +5472,13 @@
   version "15.0.8"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.8.tgz#7644904cad7427eb704331ea9bf1ee5499b82e23"
   integrity sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^16.0.0":
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.3.tgz#4b6d35bb8e680510a7dc2308518a80ee1ef27e01"
+  integrity sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -6264,6 +6588,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 ansi-to-html@^0.6.11:
   version "0.6.14"
@@ -7421,6 +7750,17 @@ browserslist@^4.14.5, browserslist@^4.16.3:
     escalade "^3.1.1"
     node-releases "^1.1.70"
 
+browserslist@^4.16.6:
+  version "4.16.6"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.6.tgz#d7901277a5a88e554ed305b183ec9b0c08f66fa2"
+  integrity sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==
+  dependencies:
+    caniuse-lite "^1.0.30001219"
+    colorette "^1.2.2"
+    electron-to-chromium "^1.3.723"
+    escalade "^3.1.1"
+    node-releases "^1.1.71"
+
 bs-logger@0.x:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
@@ -7821,6 +8161,11 @@ caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001181:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001204.tgz#256c85709a348ec4d175e847a3b515c66e79f2aa"
   integrity sha512-JUdjWpcxfJ9IPamy2f5JaRDCaqJOxDzOSKtbdx4rH9VivMd1vIzoPumsJa9LoMIi4Fx2BV2KZOxWhNkBjaYivQ==
 
+caniuse-lite@^1.0.30001219:
+  version "1.0.30001238"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001238.tgz#e6a8b45455c5de601718736d0242feef0ecdda15"
+  integrity sha512-bZGam2MxEt7YNsa2VwshqWQMwrYs5tR5WZQRYSuFxsBQunWjBuXhN4cS9nV5FFb1Z9y+DoQcQ0COyQbv6A+CKw==
+
 capture-exit@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-2.0.0.tgz#fb953bfaebeb781f62898239dabb426d08a509a4"
@@ -8078,6 +8423,11 @@ ci-info@^2.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
+ci-info@^3.1.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.2.0.tgz#2876cb948a498797b5236f0095bc057d0dca38b6"
+  integrity sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==
+
 cids@^0.7.1:
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/cids/-/cids-0.7.5.tgz#60a08138a99bfb69b6be4ceb63bfef7a396b28b2"
@@ -8101,6 +8451,11 @@ cjs-module-lexer@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz#4186fcca0eae175970aee870b9fe2d6cf8d5655f"
   integrity sha512-uc2Vix1frTfnuzxxu1Hp4ktSvM3QaI4oXl4ZUqL1wjTu/BGki9TrCWoqLTg/drR1KwAEarXuRFCG2Svr1GxPFw==
+
+cjs-module-lexer@^1.0.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.1.tgz#2fd46d9906a126965aa541345c499aaa18e8cd73"
+  integrity sha512-jVamGdJPDeuQilKhvVn1h3knuMOZzr8QDnpk+M9aMlCaMkTDd6fBWPhiDqFvFZ07pL0liqabAiuy8SY4jGHeaw==
 
 class-is@^1.1.0:
   version "1.1.0"
@@ -8238,6 +8593,15 @@ cliui@^6.0.0:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
+
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
 
 clone-deep@^4.0.1:
   version "4.0.1"
@@ -9665,6 +10029,11 @@ diff-sequences@^26.6.2:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
 
+diff-sequences@^27.0.1:
+  version "27.0.1"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.0.1.tgz#9c9801d52ed5f576ff0a20e3022a13ee6e297e7c"
+  integrity sha512-XPLijkfJUh/PIBnfkcSHgvD6tlYixmcMAn3osTk6jt+H0v/mgURto1XUiD9DKuGX5NDoVS6dSlA23gd9FUaCFg==
+
 diff@4.0.2, diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
@@ -9960,6 +10329,11 @@ electron-to-chromium@^1.3.571:
   version "1.3.578"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.578.tgz#e6671936f4571a874eb26e2e833aa0b2c0b776e0"
   integrity sha512-z4gU6dA1CbBJsAErW5swTGAaU2TBzc2mPAonJb00zqW1rOraDo2zfBMDRvaz9cVic+0JEZiYbHWPw/fTaZlG2Q==
+
+electron-to-chromium@^1.3.723:
+  version "1.3.752"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.752.tgz#0728587f1b9b970ec9ffad932496429aef750d09"
+  integrity sha512-2Tg+7jSl3oPxgsBsWKh5H83QazTkmWG/cnNwJplmyZc7KcN61+I10oUgaXSVk/NwfvN3BdkKDR4FYuRBQQ2v0A==
 
 element-resize-detector@^1.2.2:
   version "1.2.2"
@@ -10996,6 +11370,18 @@ expect@^26.6.2:
     jest-message-util "^26.6.2"
     jest-regex-util "^26.0.0"
 
+expect@^27.0.2:
+  version "27.0.2"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-27.0.2.tgz#e66ca3a4c9592f1c019fa1d46459a9d2084f3422"
+  integrity sha512-YJFNJe2+P2DqH+ZrXy+ydRQYO87oxRUonZImpDodR1G7qo3NYd3pL+NQ9Keqpez3cehczYwZDBC3A7xk3n7M/w==
+  dependencies:
+    "@jest/types" "^27.0.2"
+    ansi-styles "^5.0.0"
+    jest-get-type "^27.0.1"
+    jest-matcher-utils "^27.0.2"
+    jest-message-util "^27.0.2"
+    jest-regex-util "^27.0.1"
+
 express@^4.14.0, express@^4.16.3, express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
@@ -11776,7 +12162,7 @@ fsevents@^2.1.2, fsevents@~2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
-fsevents@~2.3.1:
+fsevents@^2.3.2, fsevents@~2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -11861,7 +12247,7 @@ get-assigned-identifiers@^1.1.0:
   resolved "https://registry.yarnpkg.com/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz#6dbf411de648cbaf8d9169ebb0d2d576191e2ff1"
   integrity sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ==
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -13315,6 +13701,13 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
+is-ci@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.0.tgz#c7e7be3c9d8eef7d0fa144390bd1e4b88dc4c994"
+  integrity sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==
+  dependencies:
+    ci-info "^3.1.1"
+
 is-color-stop@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-color-stop/-/is-color-stop-1.1.0.tgz#cfff471aee4dd5c9e158598fbe12967b5cdad345"
@@ -13988,6 +14381,31 @@ jest-circus@^26.6.3:
     stack-utils "^2.0.2"
     throat "^5.0.0"
 
+jest-circus@^27.0.4:
+  version "27.0.4"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-27.0.4.tgz#3b261514ee3b3da33def736a6352c98ff56bb6e6"
+  integrity sha512-QD+eblDiRphta630WRKewuASLs/oY1Zki2G4bccntRvrTHQ63ljwFR5TLduuK4Zg0ZPzW0+8o6AP7KRd1yKOjw==
+  dependencies:
+    "@jest/environment" "^27.0.3"
+    "@jest/test-result" "^27.0.2"
+    "@jest/types" "^27.0.2"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    co "^4.6.0"
+    dedent "^0.7.0"
+    expect "^27.0.2"
+    is-generator-fn "^2.0.0"
+    jest-each "^27.0.2"
+    jest-matcher-utils "^27.0.2"
+    jest-message-util "^27.0.2"
+    jest-runtime "^27.0.4"
+    jest-snapshot "^27.0.4"
+    jest-util "^27.0.2"
+    pretty-format "^27.0.2"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
+    throat "^6.0.1"
+
 jest-cli@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-24.9.0.tgz#ad2de62d07472d419c6abc301fc432b98b10d2af"
@@ -14103,6 +14521,16 @@ jest-diff@^26.6.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
 
+jest-diff@^27.0.2:
+  version "27.0.2"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.0.2.tgz#f315b87cee5dc134cf42c2708ab27375cc3f5a7e"
+  integrity sha512-BFIdRb0LqfV1hBt8crQmw6gGQHVDhM87SpMIZ45FPYKReZYG5er1+5pIn2zKqvrJp6WNox0ylR8571Iwk2Dmgw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^27.0.1"
+    jest-get-type "^27.0.1"
+    pretty-format "^27.0.2"
+
 jest-docblock@^24.3.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-24.9.0.tgz#7970201802ba560e1c4092cc25cbedf5af5a8ce2"
@@ -14138,6 +14566,17 @@ jest-each@^26.6.2:
     jest-get-type "^26.3.0"
     jest-util "^26.6.2"
     pretty-format "^26.6.2"
+
+jest-each@^27.0.2:
+  version "27.0.2"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-27.0.2.tgz#865ddb4367476ced752167926b656fa0dcecd8c7"
+  integrity sha512-OLMBZBZ6JkoXgUenDtseFRWA43wVl2BwmZYIWQws7eS7pqsIvePqj/jJmEnfq91ALk3LNphgwNK/PRFBYi7ITQ==
+  dependencies:
+    "@jest/types" "^27.0.2"
+    chalk "^4.0.0"
+    jest-get-type "^27.0.1"
+    jest-util "^27.0.2"
+    pretty-format "^27.0.2"
 
 jest-environment-jsdom-fifteen@^1.0.2:
   version "1.0.2"
@@ -14214,6 +14653,11 @@ jest-get-type@^26.3.0:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
   integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
 
+jest-get-type@^27.0.1:
+  version "27.0.1"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.0.1.tgz#34951e2b08c8801eb28559d7eb732b04bbcf7815"
+  integrity sha512-9Tggo9zZbu0sHKebiAijyt1NM77Z0uO4tuWOxUCujAiSeXv30Vb5D4xVF4UR4YWNapcftj+PbByU54lKD7/xMg==
+
 jest-haste-map@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-24.9.0.tgz#b38a5d64274934e21fa417ae9a9fbeb77ceaac7d"
@@ -14274,6 +14718,26 @@ jest-haste-map@^26.6.2:
     walker "^1.0.7"
   optionalDependencies:
     fsevents "^2.1.2"
+
+jest-haste-map@^27.0.2:
+  version "27.0.2"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-27.0.2.tgz#3f1819400c671237e48b4d4b76a80a0dbed7577f"
+  integrity sha512-37gYfrYjjhEfk37C4bCMWAC0oPBxDpG0qpl8lYg8BT//wf353YT/fzgA7+Dq0EtM7rPFS3JEcMsxdtDwNMi2cA==
+  dependencies:
+    "@jest/types" "^27.0.2"
+    "@types/graceful-fs" "^4.1.2"
+    "@types/node" "*"
+    anymatch "^3.0.3"
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.2.4"
+    jest-regex-util "^27.0.1"
+    jest-serializer "^27.0.1"
+    jest-util "^27.0.2"
+    jest-worker "^27.0.2"
+    micromatch "^4.0.4"
+    walker "^1.0.7"
+  optionalDependencies:
+    fsevents "^2.3.2"
 
 jest-jasmine2@^24.9.0:
   version "24.9.0"
@@ -14357,6 +14821,16 @@ jest-matcher-utils@^26.6.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
 
+jest-matcher-utils@^27.0.2:
+  version "27.0.2"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.0.2.tgz#f14c060605a95a466cdc759acc546c6f4cbfc4f0"
+  integrity sha512-Qczi5xnTNjkhcIB0Yy75Txt+Ez51xdhOxsukN7awzq2auZQGPHcQrJ623PZj0ECDEMOk2soxWx05EXdXGd1CbA==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^27.0.2"
+    jest-get-type "^27.0.1"
+    pretty-format "^27.0.2"
+
 jest-message-util@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-24.9.0.tgz#527f54a1e380f5e202a8d1149b0ec872f43119e3"
@@ -14386,6 +14860,21 @@ jest-message-util@^26.6.2:
     slash "^3.0.0"
     stack-utils "^2.0.2"
 
+jest-message-util@^27.0.2:
+  version "27.0.2"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-27.0.2.tgz#181c9b67dff504d8f4ad15cba10d8b80f272048c"
+  integrity sha512-rTqWUX42ec2LdMkoUPOzrEd1Tcm+R1KfLOmFK+OVNo4MnLsEaxO5zPDb2BbdSmthdM/IfXxOZU60P/WbWF8BTw==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@jest/types" "^27.0.2"
+    "@types/stack-utils" "^2.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    micromatch "^4.0.4"
+    pretty-format "^27.0.2"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
+
 jest-mock@^24.0.0, jest-mock@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-24.9.0.tgz#c22835541ee379b908673ad51087a2185c13f1c6"
@@ -14399,6 +14888,14 @@ jest-mock@^26.6.2:
   integrity sha512-YyFjePHHp1LzpzYcmgqkJ0nm0gg/lJx2aZFzFy1S6eUqNjXsOqTK10zNRff2dNfssgokjkG65OlWNcIlgd3zew==
   dependencies:
     "@jest/types" "^26.6.2"
+    "@types/node" "*"
+
+jest-mock@^27.0.3:
+  version "27.0.3"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-27.0.3.tgz#5591844f9192b3335c0dca38e8e45ed297d4d23d"
+  integrity sha512-O5FZn5XDzEp+Xg28mUz4ovVcdwBBPfAhW9+zJLO0Efn2qNbYcDaJvSlRiQ6BCZUCVOJjALicuJQI9mRFjv1o9Q==
+  dependencies:
+    "@jest/types" "^27.0.2"
     "@types/node" "*"
 
 jest-playwright-preset@^1.5.2:
@@ -14447,6 +14944,11 @@ jest-regex-util@^26.0.0:
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-26.0.0.tgz#d25e7184b36e39fd466c3bc41be0971e821fee28"
   integrity sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==
 
+jest-regex-util@^27.0.1:
+  version "27.0.1"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-27.0.1.tgz#69d4b1bf5b690faa3490113c47486ed85dd45b68"
+  integrity sha512-6nY6QVcpTgEKQy1L41P4pr3aOddneK17kn3HJw6SdwGiKfgCGTvH02hVXL0GU8GEKtPH83eD2DIDgxHXOxVohQ==
+
 jest-resolve-dependencies@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz#ad055198959c4cfba8a4f066c673a3f0786507ab"
@@ -14488,6 +14990,21 @@ jest-resolve@^26.6.2:
     jest-util "^26.6.2"
     read-pkg-up "^7.0.1"
     resolve "^1.18.1"
+    slash "^3.0.0"
+
+jest-resolve@^27.0.4:
+  version "27.0.4"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-27.0.4.tgz#8a27bc3f2f00c8ea28f3bc99bbf6f468300a703d"
+  integrity sha512-BcfyK2i3cG79PDb/6gB6zFeFQlcqLsQjGBqznFCpA0L/3l1L/oOsltdUjs5eISAWA9HS9qtj8v2PSZr/yWxONQ==
+  dependencies:
+    "@jest/types" "^27.0.2"
+    chalk "^4.0.0"
+    escalade "^3.1.1"
+    graceful-fs "^4.2.4"
+    jest-pnp-resolver "^1.2.2"
+    jest-util "^27.0.2"
+    jest-validate "^27.0.2"
+    resolve "^1.20.0"
     slash "^3.0.0"
 
 jest-runner@^24.9.0:
@@ -14603,6 +15120,38 @@ jest-runtime@^26.6.3:
     strip-bom "^4.0.0"
     yargs "^15.4.1"
 
+jest-runtime@^27.0.4:
+  version "27.0.4"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-27.0.4.tgz#2e4a6aa77cac32ac612dfe12768387a8aa15c2f0"
+  integrity sha512-voJB4xbAjS/qYPboV+e+gmg3jfvHJJY4CagFWBOM9dQKtlaiTjcpD2tWwla84Z7PtXSQPeIpXY0qksA9Dum29A==
+  dependencies:
+    "@jest/console" "^27.0.2"
+    "@jest/environment" "^27.0.3"
+    "@jest/fake-timers" "^27.0.3"
+    "@jest/globals" "^27.0.3"
+    "@jest/source-map" "^27.0.1"
+    "@jest/test-result" "^27.0.2"
+    "@jest/transform" "^27.0.2"
+    "@jest/types" "^27.0.2"
+    "@types/yargs" "^16.0.0"
+    chalk "^4.0.0"
+    cjs-module-lexer "^1.0.0"
+    collect-v8-coverage "^1.0.0"
+    exit "^0.1.2"
+    glob "^7.1.3"
+    graceful-fs "^4.2.4"
+    jest-haste-map "^27.0.2"
+    jest-message-util "^27.0.2"
+    jest-mock "^27.0.3"
+    jest-regex-util "^27.0.1"
+    jest-resolve "^27.0.4"
+    jest-snapshot "^27.0.4"
+    jest-util "^27.0.2"
+    jest-validate "^27.0.2"
+    slash "^3.0.0"
+    strip-bom "^4.0.0"
+    yargs "^16.0.3"
+
 jest-serializer-vue@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/jest-serializer-vue/-/jest-serializer-vue-2.0.2.tgz#b238ef286357ec6b480421bd47145050987d59b3"
@@ -14627,6 +15176,14 @@ jest-serializer@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-26.6.2.tgz#d139aafd46957d3a448f3a6cdabe2919ba0742d1"
   integrity sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==
+  dependencies:
+    "@types/node" "*"
+    graceful-fs "^4.2.4"
+
+jest-serializer@^27.0.1:
+  version "27.0.1"
+  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-27.0.1.tgz#2464d04dcc33fb71dc80b7c82e3c5e8a08cb1020"
+  integrity sha512-svy//5IH6bfQvAbkAEg1s7xhhgHTtXu0li0I2fdKHDsLP2P2MOiscPQIENQep8oU2g2B3jqLyxKKzotZOz4CwQ==
   dependencies:
     "@types/node" "*"
     graceful-fs "^4.2.4"
@@ -14670,6 +15227,36 @@ jest-snapshot@^26.6.2:
     jest-resolve "^26.6.2"
     natural-compare "^1.4.0"
     pretty-format "^26.6.2"
+    semver "^7.3.2"
+
+jest-snapshot@^27.0.4:
+  version "27.0.4"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-27.0.4.tgz#2b96e22ca90382b3e93bd0aae2ce4c78bf51fb5b"
+  integrity sha512-hnjrvpKGdSMvKfbHyaG5Kul7pDJGZvjVy0CKpzhu28MmAssDXS6GpynhXzgst1wBQoKD8c9b2VS2a5yhDLQRCA==
+  dependencies:
+    "@babel/core" "^7.7.2"
+    "@babel/generator" "^7.7.2"
+    "@babel/parser" "^7.7.2"
+    "@babel/plugin-syntax-typescript" "^7.7.2"
+    "@babel/traverse" "^7.7.2"
+    "@babel/types" "^7.0.0"
+    "@jest/transform" "^27.0.2"
+    "@jest/types" "^27.0.2"
+    "@types/babel__traverse" "^7.0.4"
+    "@types/prettier" "^2.1.5"
+    babel-preset-current-node-syntax "^1.0.0"
+    chalk "^4.0.0"
+    expect "^27.0.2"
+    graceful-fs "^4.2.4"
+    jest-diff "^27.0.2"
+    jest-get-type "^27.0.1"
+    jest-haste-map "^27.0.2"
+    jest-matcher-utils "^27.0.2"
+    jest-message-util "^27.0.2"
+    jest-resolve "^27.0.4"
+    jest-util "^27.0.2"
+    natural-compare "^1.4.0"
+    pretty-format "^27.0.2"
     semver "^7.3.2"
 
 jest-transform-stub@^2.0.0:
@@ -14719,6 +15306,18 @@ jest-util@^26.5.2:
     is-ci "^2.0.0"
     micromatch "^4.0.2"
 
+jest-util@^27.0.2:
+  version "27.0.2"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.0.2.tgz#fc2c7ace3c75ae561cf1e5fdb643bf685a5be7c7"
+  integrity sha512-1d9uH3a00OFGGWSibpNYr+jojZ6AckOMCXV2Z4K3YXDnzpkAaXQyIpY14FOJPiUmil7CD+A6Qs+lnnh6ctRbIA==
+  dependencies:
+    "@jest/types" "^27.0.2"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    is-ci "^3.0.0"
+    picomatch "^2.2.3"
+
 jest-validate@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-24.9.0.tgz#0775c55360d173cd854e40180756d4ff52def8ab"
@@ -14742,6 +15341,18 @@ jest-validate@^26.6.2:
     jest-get-type "^26.3.0"
     leven "^3.1.0"
     pretty-format "^26.6.2"
+
+jest-validate@^27.0.2:
+  version "27.0.2"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-27.0.2.tgz#7fe2c100089449cd5cbb47a5b0b6cb7cda5beee5"
+  integrity sha512-UgBF6/oVu1ofd1XbaSotXKihi8nZhg0Prm8twQ9uCuAfo59vlxCXMPI/RKmrZEVgi3Nd9dS0I8A0wzWU48pOvg==
+  dependencies:
+    "@jest/types" "^27.0.2"
+    camelcase "^6.2.0"
+    chalk "^4.0.0"
+    jest-get-type "^27.0.1"
+    leven "^3.1.0"
+    pretty-format "^27.0.2"
 
 jest-watch-typeahead@^0.4.2:
   version "0.4.2"
@@ -14820,6 +15431,15 @@ jest-worker@^26.5.0:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
+
+jest-worker@^27.0.2:
+  version "27.0.2"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.0.2.tgz#4ebeb56cef48b3e7514552f80d0d80c0129f0b05"
+  integrity sha512-EoBdilOTTyOgmHXtw/cPc+ZrCA0KJMrkXzkrPGNwLmnvvlN1nj7MPrxpT7m+otSv2e1TLaVffzDnE/LB14zJMg==
+  dependencies:
+    "@types/node" "*"
+    merge-stream "^2.0.0"
+    supports-color "^8.0.0"
 
 jest@^24.9.0:
   version "24.9.0"
@@ -16071,6 +16691,14 @@ micromatch@^4.0.0, micromatch@^4.0.2:
     braces "^3.0.1"
     picomatch "^2.0.5"
 
+micromatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
+  integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.2.3"
+
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -16750,6 +17378,11 @@ node-releases@^1.1.70:
   version "1.1.71"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.71.tgz#cb1334b179896b1c89ecfdd4b725fb7bbdfc7dbb"
   integrity sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==
+
+node-releases@^1.1.71:
+  version "1.1.73"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.73.tgz#dd4e81ddd5277ff846b80b52bb40c49edf7a7b20"
+  integrity sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==
 
 node-stream-zip@^1.13.2:
   version "1.13.2"
@@ -17841,6 +18474,11 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
+picomatch@^2.2.3:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
+  integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
+
 pid-port@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pid-port/-/pid-port-0.1.1.tgz#2ac86fa8a0e97ef2e7eb9e7e9567cdc1eda78098"
@@ -18496,6 +19134,16 @@ pretty-format@^26.6.2:
     "@jest/types" "^26.6.2"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
+pretty-format@^27.0.2:
+  version "27.0.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.0.2.tgz#9283ff8c4f581b186b2d4da461617143dca478a4"
+  integrity sha512-mXKbbBPnYTG7Yra9qFBtqj+IXcsvxsvOBco3QHxtxTl+hHKq6QdzMZ+q0CtL4ORHZgwGImRr2XZUX2EWzORxig==
+  dependencies:
+    "@jest/types" "^27.0.2"
+    ansi-regex "^5.0.0"
+    ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
 pretty-hrtime@^1.0.2, pretty-hrtime@^1.0.3:
@@ -19802,7 +20450,7 @@ resolve@1.x, resolve@^1.10.0, resolve@^1.3.2, resolve@^1.8.1:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.12.0, resolve@^1.14.2, resolve@^1.15.1, resolve@^1.18.1, resolve@^1.19.0:
+resolve@^1.12.0, resolve@^1.14.2, resolve@^1.15.1, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -21205,6 +21853,13 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
+supports-color@^8.0.0:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
+  dependencies:
+    has-flag "^4.0.0"
+
 supports-hyperlinks@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz#f663df252af5f37c5d49bbd7eeefa9e0b9e59e47"
@@ -21527,6 +22182,11 @@ throat@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
+
+throat@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/throat/-/throat-6.0.1.tgz#d514fedad95740c12c2d7fc70ea863eb51ade375"
+  integrity sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==
 
 throttle-debounce@^3.0.1:
   version "3.0.1"
@@ -24107,6 +24767,15 @@ wrap-ansi@^6.2.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-comment@^1.0.0, wrap-comment@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/wrap-comment/-/wrap-comment-1.0.1.tgz#941bb1400b9b590bc007599e79cacc0bb3ea62f3"
@@ -24299,6 +24968,11 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
 yaeti@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
@@ -24344,7 +25018,7 @@ yargs-parser@13.1.2, yargs-parser@^13.1.0, yargs-parser@^13.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@20.x:
+yargs-parser@20.x, yargs-parser@^20.2.2:
   version "20.2.7"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.7.tgz#61df85c113edfb5a7a4e36eb8aa60ef423cbc90a"
   integrity sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==
@@ -24447,6 +25121,19 @@ yargs@^15.0.0, yargs@^15.0.2, yargs@^15.4.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yargs@^16.0.3:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yauzl@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
This PR enables screenshots whenever `test` or `hook` (before or after) `fails`. It generates screenshots for all open pages. The screenshots are saved under `./screenshots` and are stored in CI as an artifact. The PR also fixes test structure by introducing `describe` blocks around tests (`it`)