### PR TITLE
fix mkdir when exists

### DIFF
--- a/ui/e2e/utils2.js
+++ b/ui/e2e/utils2.js
@@ -1,7 +1,9 @@
 const mkdirp = require("mkdirp");
+const fs = require("fs");
 
 async function takeScreenshots(name, context) {
   if (context) {
+    const screenshotsDir = "./screenshots";
     const date = new Date();
     const year = date.getFullYear();
     const month = date.getUTCMonth() + 1;
@@ -11,12 +13,14 @@ async function takeScreenshots(name, context) {
     const sec = date.getUTCSeconds();
     const dateString = `${year}-${month}-${dateOfMonth}-${hour}-${minute}-${sec}`;
 
-    const screenshotPath = `screenshots/${name.replace(
+    const screenshotPath = `${screenshotsDir}/${name.replace(
       / /g,
       "_",
     )}-${dateString}`;
 
-    await mkdirp("screenshots");
+    if (!fs.existsSync(screenshotsDir)) {
+      await mkdirp(screenshotsDir);
+    }
 
     const pages = await context.pages();
     await pages.forEach(async (page, index) => {


### PR DESCRIPTION
This PR fixes issue around screenshot files generation when target directory `./screenshots` already exists. In such case, previously test suite would fail. The PR adds guarding condition to check if the directory exists.