### PR TITLE
pinata: rm msg

### DIFF
--- a/.github/workflows/pinata-build-deploy-ui.yml
+++ b/.github/workflows/pinata-build-deploy-ui.yml
@@ -197,7 +197,6 @@ jobs:
         with:
           payload: "{\"pinata_url\":\"https://sifchain.mypinata.cloud/ipfs/${{ steps.pinata.outputs.hash }}\",
           \"branch\":\"${{ steps.extract_env.outputs.env }}\",\"github_hash\": \"${{ github.sha }}\", 
-          \"sif_url\": \"https://${{ steps.extract_env.outputs.env }}.sifchain.finance\", 
-          \"msg\": \"${{github.event.head_commit.message}}\" }"
+          \"sif_url\": \"https://${{ steps.extract_env.outputs.env }}.sifchain.finance\" }"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Needs to be sanitized. Longer commit messages, like pull requests, break the Slack workflow.