### PR TITLE
Cache Bust app.css - ui/app/vue.config: app.[hash].css

### DIFF
--- a/ui/app/vue.config.js
+++ b/ui/app/vue.config.js
@@ -42,7 +42,7 @@ module.exports = {
   },
   css: {
     extract: {
-      filename: "app.css",
+      filename: "app.[hash].css",
     },
     loaderOptions: {
       sass: {


### PR DESCRIPTION
Adds a hash to app.css so it is now app.[hash].css. This should alleviate issues now and in the future where users' browser cache loads an old app.css.

cc @mccallofthewild