### PR TITLE
Hotfix: Always use tokenregistry for clp items

### DIFF
--- a/ui/core/src/services/TokenRegistryService/TokenRegistryService.ts
+++ b/ui/core/src/services/TokenRegistryService/TokenRegistryService.ts
@@ -1,4 +1,4 @@
-import { Chain, Network, getChainsService } from "../../entities";
+import { Chain, Network, getChainsService, IAsset } from "../../entities";
 import { RegistryEntry } from "../../generated/proto/sifnode/tokenregistry/v1/types";
 import { NativeDexClient } from "../utils/SifClient/NativeDexClient";
 
@@ -19,8 +19,18 @@ export const TokenRegistryService = (context: TokenRegistryContext) => {
     return tokenRegistry;
   };
 
-  return {
+  const self = {
     load: () => loadTokenRegistry(),
+    findAssetEntry: async (asset: IAsset) => {
+      const items = await loadTokenRegistry();
+      return items.find((item) => item.baseDenom === asset.symbol);
+    },
+    findAssetEntryOrThrow: async (asset: IAsset) => {
+      const entry = await self.findAssetEntry(asset);
+      if (!entry)
+        throw new Error("TokenRegistry entry not found for " + asset.symbol);
+      return entry;
+    },
     async loadConnectionByNetworks(params: {
       sourceNetwork: Network;
       destinationNetwork: Network;
@@ -62,6 +72,7 @@ export const TokenRegistryService = (context: TokenRegistryContext) => {
       }
     },
   };
+  return self;
 };
 
 export default TokenRegistryService;


### PR DESCRIPTION
If user had 0 ATOM in their Sif wallet then tried to asymmetrically pool atom + rowan, it would send up `uatom` to API. This is because the CLP code was using the user's Keplr wallet ATOM IBC hash to determine atom's ibcDenom instead of using the tokenregistry API.

So if user had 0 ATOM in sif wallet, it would never read Atom's IBC hash, and it would default to `uatom` the symbol instead of ibc hash.

Now we use https://api.sifchain.finance/tokenregistry/entries every time.

This was an older part of the codebase that hadn't been upgraded to using tokenregistry yet (tokenregistry was only added in last 1 week)