### PR TITLE
Prevent Invalid IBC Pool Lookup

### DIFF
--- a/ui/core/src/services/ClpService/ClpService.ts
+++ b/ui/core/src/services/ClpService/ClpService.ts
@@ -157,8 +157,12 @@ export default function createClpService({
       });
     },
     async getLiquidityProvider(params) {
+      await tokenRegistry.load();
+      const entry = await tokenRegistry.findAssetEntryOrThrow(params.asset);
       const response = await client.getLiquidityProvider({
-        symbol: params.asset.ibcDenom || params.asset.symbol,
+        // cannot use params.asset.ibcDenom because ibcDenom is set when loading balances,
+        // and the user does not always have a balance for the asset they have pooled
+        symbol: entry.denom,
         lpAddress: params.lpAddress,
       });
 


### PR DESCRIPTION
Summary:
* Updated `clp.getLiquidityProvider` to pull IBC denom's from the token registry
* Prevents error in scenario where user has pooled an IBC asset, but has no balance of the asset in their wallet