### PR TITLE
Hotfix/carrd.co redirect clientside

### DIFF
--- a/ui/app/index.html
+++ b/ui/app/index.html
@@ -27,6 +27,7 @@
     <div id="app"></div>
     <div id="portal-target"></div>
     <div id="tooltip-target"></div>
+    <script>window.location.href='https://sifchain.carrd.co'</script>
     <script type="module" src="./src/main.ts"></script>
   </body>
 </html>


### PR DESCRIPTION
Our cloudflare config doesn't allow cnames on outside domains anymore. Instead putting a hotfix on FE that does a clientside redirect. 