### PR TITLE
ui/app: RewardsPage: pretty

### DIFF
--- a/ui/app/src/views/RewardsPage/components/RewardSection.tsx
+++ b/ui/app/src/views/RewardsPage/components/RewardSection.tsx
@@ -92,17 +92,15 @@ export const RewardSection = defineComponent({
           name: "Reserved Commission Rewards",
           tooltip:
             "These are rewards you have earned from your delegators, but are not yet claimable due to either: a) your delegators not claiming their portion of these rewards yet or b) those rewards for your delegators not reaching full maturity yet.  Once one of these actions happen, these rewards will be considered claimable for you.",
-          amount:
-            this.rewardProgram.participant
-              ?.currentTotalCommissionsOnClaimableDelegatorRewards,
+          amount: this.rewardProgram.participant
+            ?.currentTotalCommissionsOnClaimableDelegatorRewards,
         },
         {
           name: "Pending Dispensation",
           tooltip:
             "This is the amount that will be dispensed on Tuesday. Any new claimable amounts will need to be claimed after the next dispensation.",
-          amount:
-            this.rewardProgram.participant
-              ?.claimedCommissionsAndRewardsAwaitingDispensation,
+          amount: this.rewardProgram.participant
+            ?.claimedCommissionsAndRewardsAwaitingDispensation,
         },
         {
           name: "Dispensed Rewards",


### PR DESCRIPTION
## yarn build fails without this

During the build:

```
...
✓ 4844 modules transformed.
[warn] Code style issues found in the above file(s). Forgot to run Prettier?
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: [warn] app/src/views/RewardsPage/components/RewardSection.tsx
[warn] Code style issues found in the above file(s). Forgot to run Prettier?
error Command failed with exit code 1.
    at lint (file:///root/sifchain-ui/ui/scripts/lib.mjs:8:11)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
The command '/bin/sh -c yarn build' returned a non-zero code: 1
```

Manual check:

```
$ yarn prettier --config .prettierrc -c 'app/src/views/RewardsPage/components/RewardSection.tsx'
yarn run v1.22.17
$ /home/arno/git/sifchain-ui/ui/node_modules/.bin/prettier --config .prettierrc -c app/src/views/RewardsPage/components/RewardSection.tsx
Checking formatting...
[warn] app/src/views/RewardsPage/components/RewardSection.tsx
[warn] Code style issues found in the above file(s). Forgot to run Prettier?
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
$ echo $?
1
```

## Auto-fix

```
$ yarn prettier -w --config .prettierrc -c 'app/src/views/RewardsPage/components/RewardSection.tsx'
yarn run v1.22.17
$ /home/arno/git/sifchain-ui/ui/node_modules/.bin/prettier -w --config .prettierrc -c app/src/views/RewardsPage/components/RewardSection.tsx
Checking formatting...
[warn] app/src/views/RewardsPage/components/RewardSection.tsx
[warn] Code style issues fixed in the above file(s).
Done in 0.35s.
$ echo $?
0
```