### PR TITLE
fix: flaky references

### DIFF
--- a/core/src/entities/Pool.ts
+++ b/core/src/entities/Pool.ts
@@ -14,117 +14,111 @@ export type Pool = ReturnType<typeof Pool>;
 
 export type IPool = Omit<Pool, "poolUnits" | "calculatePoolUnits">;
 
-export function Pool(a: IAssetAmount, b: IAssetAmount, poolUnits?: IAmount) {
-  const pair = Pair(a, b);
-  const amounts: [IAssetAmount, IAssetAmount] = pair.amounts;
-
-  return {
-    amounts,
-    get externalAmount() {
-      return amounts.find((amount) => amount.symbol !== "rowan")!;
-    },
-    get nativeAmount() {
-      return amounts.find((amount) => amount.symbol === "rowan")!;
-    },
-    otherAsset: pair.otherAsset,
-    symbol: pair.symbol,
-    contains: pair.contains,
-    toString: pair.toString,
-    getAmount: pair.getAmount,
-    poolUnits:
-      poolUnits ||
-      calculatePoolUnits(
-        Amount(a),
-        Amount(b),
-        Amount("0"),
-        Amount("0"),
-        Amount("0"),
-      ),
-    priceAsset(asset: IAsset) {
-      return this.calcSwapResult(AssetAmount(asset, "1"));
-    },
-
-    calcProviderFee(x: IAssetAmount) {
-      const X = amounts.find((a) => a.symbol === x.symbol);
-      if (!X)
-        throw new Error(
-          `Sent amount with symbol ${
-            x.symbol
-          } does not exist in this pair: ${this.toString()}`,
-        );
-      const Y = amounts.find((a) => a.symbol !== x.symbol);
-      if (!Y) throw new Error("Pool does not have an opposite asset."); // For Typescript's sake will probably never happen
-      const providerFee = calculateProviderFee(x, X, Y);
-      return AssetAmount(this.otherAsset(x), providerFee);
-    },
-
-    calcPriceImpact(x: IAssetAmount) {
-      const X = amounts.find((a) => a.symbol === x.symbol);
-      if (!X)
-        throw new Error(
-          `Sent amount with symbol ${
-            x.symbol
-          } does not exist in this pair: ${this.toString()}`,
-        );
-      return calculatePriceImpact(x, X).multiply("100");
-    },
-
-    // https://github.com/Sifchain/sifnode/blob/develop/docs/1.Liquidity%20Pools%20Architecture.md
-    // Formula: swapAmount = (x * X * Y) / (x + X) ^ 2
-    calcSwapResult(x: IAssetAmount) {
-      const X = amounts.find((a) => a.symbol === x.symbol);
-      if (!X)
-        throw new Error(
-          `Sent amount with symbol ${
-            x.symbol
-          } does not exist in this pair: ${this.toString()}`,
-        );
-      const Y = amounts.find((a) => a.symbol !== x.symbol);
-      if (!Y) throw new Error("Pool does not have an opposite asset."); // For Typescript's sake will probably never happen
-      const swapAmount = calculateSwapResult(x, X, Y);
-      return AssetAmount(this.otherAsset(x), swapAmount);
-    },
-
-    calcReverseSwapResult(Sa: IAssetAmount): IAssetAmount {
-      const Ya = amounts.find((a) => a.symbol === Sa.symbol);
-      if (!Ya)
-        throw new Error(
-          `Sent amount with symbol ${
-            Sa.symbol
-          } does not exist in this pair: ${this.toString()}`,
-        );
-      const Xa = amounts.find((a) => a.symbol !== Sa.symbol);
-      if (!Xa) throw new Error("Pool does not have an opposite asset."); // For Typescript's sake will probably never happen
-      const otherAsset = this.otherAsset(Sa);
-      if (Sa.equalTo("0")) {
-        return AssetAmount(otherAsset, "0");
-      }
-
-      const x = calculateReverseSwapResult(Sa, Xa, Ya);
-
-      return AssetAmount(otherAsset, x);
-    },
-
+export const Pool = (
+  a: IAssetAmount,
+  b: IAssetAmount,
+  poolUnits?: IAmount,
+) => ({
+  ...Pair(a, b),
+  get externalAmount(): IAssetAmount {
+    return this.amounts.find((amount) => amount.symbol !== "rowan")!;
+  },
+  get nativeAmount(): IAssetAmount {
+    return this.amounts.find((amount) => amount.symbol === "rowan")!;
+  },
+  poolUnits:
+    poolUnits ||
     calculatePoolUnits(
-      nativeAssetAmount: IAssetAmount,
-      externalAssetAmount: IAssetAmount,
-    ) {
-      const [nativeBalanceBefore, externalBalanceBefore] = amounts;
+      Amount(a),
+      Amount(b),
+      Amount("0"),
+      Amount("0"),
+      Amount("0"),
+    ),
+  priceAsset(asset: IAsset) {
+    return this.calcSwapResult(AssetAmount(asset, "1"));
+  },
 
-      // Calculate current units created by this potential liquidity provision
-      const lpUnits = calculatePoolUnits(
-        nativeAssetAmount,
-        externalAssetAmount,
-        nativeBalanceBefore,
-        externalBalanceBefore,
-        this.poolUnits,
+  calcProviderFee(x: IAssetAmount) {
+    const X = this.amounts.find((a) => a.symbol === x.symbol);
+    if (!X)
+      throw new Error(
+        `Sent amount with symbol ${
+          x.symbol
+        } does not exist in this pair: ${this.toString()}`,
       );
-      const newTotalPoolUnits = lpUnits.add(this.poolUnits);
+    const Y = this.amounts.find((a) => a.symbol !== x.symbol);
+    if (!Y) throw new Error("Pool does not have an opposite asset."); // For Typescript's sake will probably never happen
+    const providerFee = calculateProviderFee(x, X, Y);
+    return AssetAmount(this.otherAsset(x), providerFee);
+  },
 
-      return [newTotalPoolUnits, lpUnits];
-    },
-  };
-}
+  calcPriceImpact(x: IAssetAmount) {
+    const X = this.amounts.find((a) => a.symbol === x.symbol);
+    if (!X)
+      throw new Error(
+        `Sent amount with symbol ${
+          x.symbol
+        } does not exist in this pair: ${this.toString()}`,
+      );
+    return calculatePriceImpact(x, X).multiply("100");
+  },
+
+  // https://github.com/Sifchain/sifnode/blob/develop/docs/1.Liquidity%20Pools%20Architecture.md
+  // Formula: swapAmount = (x * X * Y) / (x + X) ^ 2
+  calcSwapResult(x: IAssetAmount) {
+    const X = this.amounts.find((a) => a.symbol === x.symbol);
+    if (!X)
+      throw new Error(
+        `Sent amount with symbol ${
+          x.symbol
+        } does not exist in this pair: ${this.toString()}`,
+      );
+    const Y = this.amounts.find((a) => a.symbol !== x.symbol);
+    if (!Y) throw new Error("Pool does not have an opposite asset."); // For Typescript's sake will probably never happen
+    const swapAmount = calculateSwapResult(x, X, Y);
+    return AssetAmount(this.otherAsset(x), swapAmount);
+  },
+
+  calcReverseSwapResult(Sa: IAssetAmount): IAssetAmount {
+    const Ya = this.amounts.find((a) => a.symbol === Sa.symbol);
+    if (!Ya)
+      throw new Error(
+        `Sent amount with symbol ${
+          Sa.symbol
+        } does not exist in this pair: ${this.toString()}`,
+      );
+    const Xa = this.amounts.find((a) => a.symbol !== Sa.symbol);
+    if (!Xa) throw new Error("Pool does not have an opposite asset."); // For Typescript's sake will probably never happen
+    const otherAsset = this.otherAsset(Sa);
+    if (Sa.equalTo("0")) {
+      return AssetAmount(otherAsset, "0");
+    }
+
+    const x = calculateReverseSwapResult(Sa, Xa, Ya);
+
+    return AssetAmount(otherAsset, x);
+  },
+
+  calculatePoolUnits(
+    nativeAssetAmount: IAssetAmount,
+    externalAssetAmount: IAssetAmount,
+  ) {
+    const [nativeBalanceBefore, externalBalanceBefore] = this.amounts;
+
+    // Calculate current units created by this potential liquidity provision
+    const lpUnits = calculatePoolUnits(
+      nativeAssetAmount,
+      externalAssetAmount,
+      nativeBalanceBefore,
+      externalBalanceBefore,
+      this.poolUnits,
+    );
+    const newTotalPoolUnits = lpUnits.add(this.poolUnits);
+
+    return [newTotalPoolUnits, lpUnits];
+  },
+});
 
 export function CompositePool(pair1: IPool, pair2: IPool): IPool {
   // The combined asset is the


### PR DESCRIPTION
somehow amounts weren't captured correctly in closure when moving between pages
which results in amounts being `[undefined, undefined]`

fixed Sifchain/issues#1381