### PR TITLE
Hotfix/2.7.10 - staging

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "2.7.9",
+  "version": "2.7.10",
   "private": true,
   "scripts": {
     "bump": "bump patch --tag --commit 'testnet release '",

--- a/app/src/components/NavSidePanel/NavSidePanel.tsx
+++ b/app/src/components/NavSidePanel/NavSidePanel.tsx
@@ -146,11 +146,6 @@ export default defineComponent({
                   href="/stats"
                 />
                 <NavSidePanelItem
-                  displayName="Rewards"
-                  icon="navigation/rewards"
-                  href="/rewards"
-                />
-                <NavSidePanelItem
                   displayName="Stake"
                   icon="navigation/stake"
                   href="https://wallet.keplr.app/#/sifchain/stake"

--- a/app/src/views/PoolPage/PoolItem.tsx
+++ b/app/src/views/PoolPage/PoolItem.tsx
@@ -221,10 +221,7 @@ export default defineComponent({
               ) && [
                 <span class="flex items-center gap-1">
                   Your total LP distribution for this pool{" "}
-                  <ExternalLink
-                    href={`/balances?focused=rowan`}
-                    label="view balance"
-                  />
+                  <ExternalLink href={`/balances`} label="view balance" />
                 </span>,
                 <span class="flex items-center font-mono">
                   {prettyNumber(
@@ -243,10 +240,7 @@ export default defineComponent({
               ) && [
                 <span class="flex items-center gap-1">
                   Your total reward distribution for this pool{" "}
-                  <ExternalLink
-                    href={`/balances?focused=rowan`}
-                    label="view balance"
-                  />
+                  <ExternalLink href={`/balances`} label="view balance" />
                 </span>,
                 <span class="flex items-center font-mono">
                   {prettyNumber(this.lppdRewards.poolRewardsReceivedInRowan)}

--- a/core/src/clients/chains/JunoChain.ts
+++ b/core/src/clients/chains/JunoChain.ts
@@ -4,7 +4,7 @@ import { BaseChain } from "./_BaseChain";
 
 export class JunoChain extends BaseChain implements Chain {
   getBlockExplorerUrlForTxHash(hash: string) {
-    return urlJoin(this.chainConfig.blockExplorerUrl, "tx", hash);
+    return urlJoin(this.chainConfig.blockExplorerUrl, "txs", hash);
   }
   getBlockExplorerUrlForAddress(hash: string) {
     return urlJoin(this.chainConfig.blockExplorerUrl, "account", hash);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sifchain-ui",
-  "version": "2.7.9",
+  "version": "2.7.10",
   "private": true,
   "license": "UNLICENSED",
   "packageManager": "yarn@3.2.0",

--- a/wallet-keplr/package.json
+++ b/wallet-keplr/package.json
@@ -10,8 +10,8 @@
     "@cosmjs/proto-signing": "^0.28.11",
     "@cosmjs/stargate": "^0.28.11",
     "@cosmjs/tendermint-rpc": "^0.28.11",
-    "@keplr-wallet/cosmos": "^0.10.14",
-    "@keplr-wallet/stores": "^0.10.14",
+    "@keplr-wallet/cosmos": "^0.9.16",
+    "@keplr-wallet/stores": "^0.9.16",
     "@sifchain/sdk": "workspace:*"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4180,6 +4180,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hanchon/ethermint-address-converter@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@hanchon/ethermint-address-converter@npm:1.1.0"
+  dependencies:
+    bech32: ^1.1.3
+    crypto-addr-codec: ^0.1.7
+  checksum: d9f1bd6af9f4cf6e178962df8dd806c768a9a8bf63c447f61867477771e1940b100de448fda4fde6b4f64423811632aacef81a21c5a349aee21d166cdee8c0c0
+  languageName: node
+  linkType: hard
+
 "@hapi/hoek@npm:^9.0.0":
   version: 9.2.1
   resolution: "@hapi/hoek@npm:9.2.1"
@@ -4687,23 +4697,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@keplr-wallet/background@npm:0.10.14":
-  version: 0.10.14
-  resolution: "@keplr-wallet/background@npm:0.10.14"
+"@keplr-wallet/background@npm:^0.9.17":
+  version: 0.9.17
+  resolution: "@keplr-wallet/background@npm:0.9.17"
   dependencies:
     "@cosmjs/launchpad": ^0.24.0-alpha.25
     "@cosmjs/proto-signing": ^0.24.0-alpha.25
     "@ethersproject/bytes": ^5.5.0
     "@ethersproject/keccak256": ^5.5.0
     "@ethersproject/wallet": ^5.5.0
-    "@keplr-wallet/common": 0.10.14
-    "@keplr-wallet/cosmos": 0.10.14
-    "@keplr-wallet/crypto": 0.10.14
-    "@keplr-wallet/popup": 0.10.14
-    "@keplr-wallet/proto-types": 0.10.14
-    "@keplr-wallet/router": 0.10.14
-    "@keplr-wallet/types": 0.10.14
-    "@keplr-wallet/unit": 0.10.14
+    "@keplr-wallet/common": ^0.9.10
+    "@keplr-wallet/cosmos": ^0.9.16
+    "@keplr-wallet/crypto": ^0.9.10
+    "@keplr-wallet/popup": ^0.9.6
+    "@keplr-wallet/router": ^0.9.6
+    "@keplr-wallet/types": ^0.9.12
+    "@keplr-wallet/unit": ^0.9.12
     "@ledgerhq/hw-transport": ^6.20.0
     "@ledgerhq/hw-transport-webhid": ^6.20.0
     "@ledgerhq/hw-transport-webusb": ^6.20.0
@@ -4718,120 +4727,95 @@ __metadata:
     ledger-cosmos-js: ^2.1.8
     long: ^4.0.0
     pbkdf2: ^3.1.2
+    reflect-metadata: ^0.1.13
     secp256k1: ^4.0.2
     secretjs: ^0.17.0
-    utility-types: ^3.10.0
-  checksum: 35e5c28657644af4dbda02613e010ea948ebe5f32c7d0bef7f644bdb7c11e2b756ef30a86dc14e89f5b53c98c40493b9457b6b3d558b80bdcc28b077685fb71a
+    tsyringe: ^4.5.0
+  checksum: 581481bf11ab0767baa9e0cd866e1381deed691a0d9db4b0a025a3dd627d3f4eb1edfbf5ec2aabd099f3d27fbb705b3f857ae0b75ade2be0d30178be544e65f2
   languageName: node
   linkType: hard
 
-"@keplr-wallet/common@npm:0.10.14":
-  version: 0.10.14
-  resolution: "@keplr-wallet/common@npm:0.10.14"
+"@keplr-wallet/common@npm:^0.9.10":
+  version: 0.9.10
+  resolution: "@keplr-wallet/common@npm:0.9.10"
   dependencies:
-    "@keplr-wallet/crypto": 0.10.14
+    "@keplr-wallet/crypto": ^0.9.10
     buffer: ^6.0.3
     delay: ^4.4.0
-  checksum: af5b150a4d2444af809fe63899799fa6ebc3971f3a244b60b6637cf413e3188594c6872b318f12aa376604e8a8f1ac32a9ea7af2a8aa68a4ea7587837452efe5
+  checksum: cdc76bf98572a2abaef5815930ee3bac75142789c76256193df89e7256afb143c1d543e6f7fe9462836488d33d9819490623c674a2f1bda6e8ad594b9e517d00
   languageName: node
   linkType: hard
 
-"@keplr-wallet/cosmos@npm:0.10.14, @keplr-wallet/cosmos@npm:^0.10.14":
-  version: 0.10.14
-  resolution: "@keplr-wallet/cosmos@npm:0.10.14"
+"@keplr-wallet/cosmos@npm:^0.9.16":
+  version: 0.9.16
+  resolution: "@keplr-wallet/cosmos@npm:0.9.16"
   dependencies:
     "@cosmjs/launchpad": ^0.24.0-alpha.25
-    "@keplr-wallet/crypto": 0.10.14
-    "@keplr-wallet/proto-types": 0.10.14
-    "@keplr-wallet/types": 0.10.14
-    "@keplr-wallet/unit": 0.10.14
+    "@keplr-wallet/crypto": ^0.9.10
+    "@keplr-wallet/types": ^0.9.12
+    "@keplr-wallet/unit": ^0.9.12
     axios: ^0.21.4
     bech32: ^1.1.4
     buffer: ^6.0.3
     long: ^4.0.0
-    protobufjs: ^6.11.2
-  checksum: 36facd835fcadda8b64260f06ef734ecdacf6a28ee5e77e58ac25348c3fb45977d2e8218d437dcfb4ac5b58005c0f62cf52f89c884d894da3b3f687d93a682a5
+    protobufjs: ^6.10.2
+  checksum: 782d17503c1e4122f3aaa616686d24c422c316bb2c38a4400a1ce922e855e4c3c9a0844c68c720fdf43c0ff1039bf1a84151f4b50d0f31eedced4ad028225950
   languageName: node
   linkType: hard
 
-"@keplr-wallet/crypto@npm:0.10.14":
-  version: 0.10.14
-  resolution: "@keplr-wallet/crypto@npm:0.10.14"
+"@keplr-wallet/crypto@npm:^0.9.10":
+  version: 0.9.10
+  resolution: "@keplr-wallet/crypto@npm:0.9.10"
   dependencies:
     bip32: ^2.0.6
     bip39: ^3.0.3
-    bs58check: ^2.1.2
     buffer: ^6.0.3
     crypto-js: ^4.0.0
     elliptic: ^6.5.3
     sha.js: ^2.4.11
-  checksum: 85047bc682a4aa4ea9eb3308313cb2d85fe28e2dd545fcbed39f86de88e123feda3725032c448f21dcf12d02d0eace24f2ba9c9de601a579ddd766fc0a6df5ca
+  checksum: 3f6e038f76d15c84659aaaaad173c3d50eac78c701e032fbdf567cb06a898911ca3b06a1d1ce2499ff557bb86555619b065d79a6f1a349473ac5186349fa8bb1
   languageName: node
   linkType: hard
 
-"@keplr-wallet/popup@npm:0.10.14":
-  version: 0.10.14
-  resolution: "@keplr-wallet/popup@npm:0.10.14"
-  checksum: 4d625b79a245e2131e849c2f9c0170bfdd8b70a690d7196143cc9b0588859303d8e40e7521bdeed0ce2447d8f92dde264106bd19c51f6076176eb8fbf2ce954a
+"@keplr-wallet/popup@npm:^0.9.6":
+  version: 0.9.6
+  resolution: "@keplr-wallet/popup@npm:0.9.6"
+  checksum: fa9ad87faf9113f295ba9186963fd9022177d8cc64098612fb64fbd568f6efc055544c88792413b3b40e2659da2a6fff230f858f5044478de7753c5ac6df2c64
   languageName: node
   linkType: hard
 
-"@keplr-wallet/proto-types@npm:0.10.14":
-  version: 0.10.14
-  resolution: "@keplr-wallet/proto-types@npm:0.10.14"
-  dependencies:
-    long: ^4.0.0
-    protobufjs: ^6.11.2
-  checksum: 09a70490ee450c61ea833cceefe26da684f8f5deb6ebdbbec448908b08699c738655a9edc21c0b809ae218edaf2dc037abfaac5b332291332a6c01016d49fd6e
+"@keplr-wallet/router@npm:^0.9.6":
+  version: 0.9.6
+  resolution: "@keplr-wallet/router@npm:0.9.6"
+  checksum: 22c3519683615f11a07532c937d9430a5bd268c69ac5fa95ef285bea510dbb419714ac272e5dc768824df0d79689f193b4b447faeb7bd8a568dbacabf949f881
   languageName: node
   linkType: hard
 
-"@keplr-wallet/router@npm:0.10.14":
-  version: 0.10.14
-  resolution: "@keplr-wallet/router@npm:0.10.14"
-  checksum: a5dc5ad682ee549c4b1112e6a7f84964af0ba630e9eef9518fca8fc6048ffb5dba70267e868d81c22aa62bb45d8c78315d32b44bfef500646726d0d52d11ca38
-  languageName: node
-  linkType: hard
-
-"@keplr-wallet/stores@npm:^0.10.14":
-  version: 0.10.14
-  resolution: "@keplr-wallet/stores@npm:0.10.14"
+"@keplr-wallet/stores@npm:^0.9.16":
+  version: 0.9.18
+  resolution: "@keplr-wallet/stores@npm:0.9.18"
   dependencies:
     "@cosmjs/encoding": ^0.24.0-alpha.25
     "@cosmjs/launchpad": ^0.24.0-alpha.25
     "@cosmjs/tendermint-rpc": ^0.24.1
-    "@ethersproject/address": ^5.6.0
-    "@keplr-wallet/background": 0.10.14
-    "@keplr-wallet/common": 0.10.14
-    "@keplr-wallet/cosmos": 0.10.14
-    "@keplr-wallet/crypto": 0.10.14
-    "@keplr-wallet/proto-types": 0.10.14
-    "@keplr-wallet/router": 0.10.14
-    "@keplr-wallet/types": 0.10.14
-    "@keplr-wallet/unit": 0.10.14
-    "@tharsis/address-converter": ^0.1.5
+    "@hanchon/ethermint-address-converter": ^1.1.0
+    "@keplr-wallet/background": ^0.9.17
+    "@keplr-wallet/common": ^0.9.10
+    "@keplr-wallet/cosmos": ^0.9.16
+    "@keplr-wallet/crypto": ^0.9.10
+    "@keplr-wallet/router": ^0.9.6
+    "@keplr-wallet/types": ^0.9.12
+    "@keplr-wallet/unit": ^0.9.12
     axios: ^0.21.4
     buffer: ^6.0.3
     deepmerge: ^4.2.2
     eventemitter3: ^4.0.7
+    long: ^4.0.0
     mobx: ^6.1.7
     mobx-utils: ^6.0.3
     p-queue: ^6.6.2
     utility-types: ^3.10.0
-  checksum: e8e013668a3662c3ee34d2c262a8daf6c60c30533d392fa77473a89e49e892ab6c4e336dd842e74389859aa109072f64960d99bc9e8f1be0ca5bbdd08873071c
-  languageName: node
-  linkType: hard
-
-"@keplr-wallet/types@npm:0.10.14":
-  version: 0.10.14
-  resolution: "@keplr-wallet/types@npm:0.10.14"
-  dependencies:
-    "@cosmjs/launchpad": ^0.24.0-alpha.25
-    "@cosmjs/proto-signing": ^0.24.0-alpha.25
-    axios: ^0.21.4
-    long: ^4.0.0
-    secretjs: ^0.17.0
-  checksum: 5e6406419d7cbf69c5e3340448f492ca4eb1b660e6201cc4803dd0ffd7759d7add4b83f526bf2a8be0273066da384947ee67ef9cd82da31849339bf61dabc545
+  checksum: c8a339bff9dbb24404b7c608275ff269e9897c2f32de6757136b98291784a378f9afc7687912272f05cf9cd4a328d4da399615cc82a45e68a6b85f234071f692
   languageName: node
   linkType: hard
 
@@ -4848,14 +4832,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@keplr-wallet/unit@npm:0.10.14":
-  version: 0.10.14
-  resolution: "@keplr-wallet/unit@npm:0.10.14"
+"@keplr-wallet/unit@npm:^0.9.12":
+  version: 0.9.12
+  resolution: "@keplr-wallet/unit@npm:0.9.12"
   dependencies:
-    "@keplr-wallet/types": 0.10.14
+    "@keplr-wallet/types": ^0.9.12
     big-integer: ^1.6.48
     utility-types: ^3.10.0
-  checksum: 6ab27ac71791a3d5af487d4696e3d82e057cbc4b84038196d9a5282066350aa296f3d27a25d589c2173188960fdc3b6b9e3df89d8e5173e6ba7ef365e98919bc
+  checksum: 84f5e9af666bf28e6bc98ec4f552018419a4d534ca0b334a3b8ef6804e56566b654836b6a8b1a0cad5af8a044a8b412a9c8f59a5f70d8b9648acc56567252cb3
   languageName: node
   linkType: hard
 
@@ -5497,8 +5481,8 @@ __metadata:
     "@cosmjs/proto-signing": ^0.28.11
     "@cosmjs/stargate": ^0.28.11
     "@cosmjs/tendermint-rpc": ^0.28.11
-    "@keplr-wallet/cosmos": ^0.10.14
-    "@keplr-wallet/stores": ^0.10.14
+    "@keplr-wallet/cosmos": ^0.9.16
+    "@keplr-wallet/stores": ^0.9.16
     "@sifchain/sdk": "workspace:*"
   languageName: unknown
   linkType: soft
@@ -23572,7 +23556,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reflect-metadata@npm:0.1.13":
+"reflect-metadata@npm:0.1.13, reflect-metadata@npm:^0.1.13":
   version: 0.1.13
   resolution: "reflect-metadata@npm:0.1.13"
   checksum: 798d379a7b6f6455501145419505c97dd11cbc23857a386add2b9ef15963ccf15a48d9d15507afe01d4cd74116df8a213247200bac00320bd7c11ddeaa5e8fb4
@@ -26339,7 +26323,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.8.1, tslib@npm:^1.9.0":
+"tslib@npm:^1.8.1, tslib@npm:^1.9.0, tslib@npm:^1.9.3":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
@@ -26354,6 +26338,15 @@ __metadata:
   peerDependencies:
     typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
   checksum: 1843f4c1b2e0f975e08c4c21caa4af4f7f65a12ac1b81b3b8489366826259323feb3fc7a243123453d2d1a02314205a7634e048d4a8009921da19f99755cdc48
+  languageName: node
+  linkType: hard
+
+"tsyringe@npm:^4.5.0":
+  version: 4.7.0
+  resolution: "tsyringe@npm:4.7.0"
+  dependencies:
+    tslib: ^1.9.3
+  checksum: 6d84e0767538fabf60eafb926bd285d08d25847875b635f8a3ab8b3093c8814aca4f47072fbb51837bd431259dc2464572e5c28a838b833c9ef097d5b1a895b3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* revert `@keplr-wallet/cosmos` to `0.9.x`
* revert `@keplr-wallet/stores` to `0.9.x`
* fix Juno's block explorer link
* remove duplicated `external link` icon from Rowan Faucet menu item