### PR TITLE
feat: enable referrer to Margin v3

### DIFF
--- a/app/src/components/NavSidePanel/NavSidePanel.tsx
+++ b/app/src/components/NavSidePanel/NavSidePanel.tsx
@@ -2,7 +2,7 @@ import { defineComponent, onMounted, ref, watch, computed } from "vue";
 import { RouterLink, useRouter } from "vue-router";
 
 import { accountStore } from "@/store/modules/accounts";
-import { flagsStore } from "@/store/modules/flags";
+import { flagsStore, MARGIN_FE_URL } from "@/store/modules/flags";
 import { governanceStore } from "@/store/modules/governance";
 import Logo from "@/assets/logo-large.svg";
 import useChangeLog from "@/hooks/useChangeLog";
@@ -29,8 +29,6 @@ try {
 } catch (_) {
   // do nothing
 }
-
-const MARGIN_FE_URL = "https://sifchain-margin.vercel.app";
 
 export default defineComponent({
   setup() {

--- a/app/src/components/NavSidePanel/NavSidePanelItem.tsx
+++ b/app/src/components/NavSidePanel/NavSidePanelItem.tsx
@@ -54,10 +54,13 @@ export default defineComponent({
       return !isExternal.value && linkRef?.isActive?.value;
     });
 
+    const isMarginUrl = props.href === MARGIN_FE_URL;
     let rel = "noopener noreferrer";
+    let target = "_blank";
 
-    if (props.href === MARGIN_FE_URL) {
+    if (isMarginUrl) {
       rel = "noopener";
+      target = "_self";
     }
 
     return () => {
@@ -66,7 +69,7 @@ export default defineComponent({
           {...(isExternal.value && {
             href: props.href,
             rel,
-            target: "_blank",
+            target,
           })}
           {...(Cmp.value === RouterLink && {
             to: props.href,
@@ -92,7 +95,7 @@ export default defineComponent({
           >
             {props.displayName}
 
-            {isExternal.value && (
+            {isExternal.value && !isMarginUrl (
               <AssetIcon
                 icon="interactive/open-external"
                 size={16}

--- a/app/src/components/NavSidePanel/NavSidePanelItem.tsx
+++ b/app/src/components/NavSidePanel/NavSidePanelItem.tsx
@@ -53,12 +53,18 @@ export default defineComponent({
       return !isExternal.value && linkRef?.isActive?.value;
     });
 
+    let rel = "noopener noreferrer";
+
+    if (props.href.includes("-margin.")) {
+      rel = "noopener";
+    }
+
     return () => {
       return (
         <Cmp.value
           {...(isExternal.value && {
             href: props.href,
-            rel: "noopener noreferrer",
+            rel,
             target: "_blank",
           })}
           {...(Cmp.value === RouterLink && {

--- a/app/src/components/NavSidePanel/NavSidePanelItem.tsx
+++ b/app/src/components/NavSidePanel/NavSidePanelItem.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx";
 import { defineComponent, PropType, HTMLAttributes, computed } from "vue";
 import { useLink, RouterLink } from "vue-router";
+import { MARGIN_FE_URL } from "@/store/modules/flags";
 import AssetIcon, { IconName } from "../AssetIcon";
 
 export default defineComponent({
@@ -55,7 +56,7 @@ export default defineComponent({
 
     let rel = "noopener noreferrer";
 
-    if (props.href.includes("-margin.")) {
+    if (props.href === MARGIN_FE_URL) {
       rel = "noopener";
     }
 

--- a/app/src/store/modules/flags.ts
+++ b/app/src/store/modules/flags.ts
@@ -3,6 +3,8 @@ import { Chain, IAsset } from "@sifchain/sdk";
 
 import { Vuextra } from "../Vuextra";
 
+export const MARGIN_FE_URL = "https://sifchain-margin.vercel.app";
+
 export const isChainFlaggedDisabled = (chain: Chain) => {
   return (
     flagsStore.state.enableTestChains[


### PR DESCRIPTION
### summary
- enable link referrer when `href` is Margin v3
- in Margin v3, on commit https://github.com/Sifchain/sifchain-ui-next/commit/8769cb1f4b29458ca2f93f9b0b8598bf5573a98a, we are looking at `document.referrer` and pointing back to target page