### PR TITLE
Comment out redundant margin apr data

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "2.14.19",
+  "version": "2.14.20",
   "private": true,
   "scripts": {
     "bump": "bump patch --tag --commit 'testnet release '",

--- a/app/src/views/StatsPage/StatsPage.tsx
+++ b/app/src/views/StatsPage/StatsPage.tsx
@@ -261,11 +261,11 @@ export default defineComponent({
                       <td class="text-mono text-right align-middle">
                         {item.poolApr}%
                       </td>
-                      <td class="text-mono text-right align-middle">
+                      {/* <td class="text-mono text-right align-middle">
                         {!isNil(item.marginApr)
                           ? `${prettyNumberMinMax(item.marginApr ?? 0)}%`
                           : "..."}
-                      </td>
+                      </td> */}
                     </tr>
                   );
                 })}


### PR DESCRIPTION
After this change, stats are looking clean and tidy:
<img width="1013" alt="image" src="https://github.com/Sifchain/sifchain-ui/assets/4013866/6584f10f-0ed0-4924-988c-76759ac463bd">
