### PR TITLE
Fix/sorting

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "2.14.23",
+  "version": "2.14.24",
   "private": true,
   "scripts": {
     "bump": "bump patch --tag --commit 'testnet release '",

--- a/app/src/views/PoolPage/PoolItem.tsx
+++ b/app/src/views/PoolPage/PoolItem.tsx
@@ -401,9 +401,9 @@ export default defineComponent({
               "flex items-center justify-end font-mono",
             ]}
           >
-            {isNil(this.$props.poolStat?.poolApr)
+            {isNil(this.$props.poolStat?.rewardApr)
               ? "..."
-              : `${(Number(this.$props.poolStat?.poolApr) ?? 0).toFixed(2)}%`}
+              : `${(Number(this.$props.poolStat?.rewardApr) ?? 0).toFixed(2)}%`}
           </div>
           <div
             class={[

--- a/app/src/views/PoolPage/PoolPage.tsx
+++ b/app/src/views/PoolPage/PoolPage.tsx
@@ -29,7 +29,7 @@ export default defineComponent({
   name: "PoolsPage",
   data() {
     return {
-      sortBy: "rowanApr" as PoolPageColumnId,
+      sortBy: "pairedApr" as PoolPageColumnId,
       sortReverse: false,
       searchQuery: "",
       showSmallPools: true,
@@ -119,14 +119,20 @@ export default defineComponent({
               const bAsset = b.pool.externalAmount?.asset.displaySymbol;
               return aAsset.localeCompare(bAsset);
             }
-            case "rewardApr":
+            case "rowanApr":
               return (
                 Number(b.poolStat?.rewardApr) - Number(a.poolStat?.rewardApr)
+              );
+            case "pairedApr":
+              return (
+                Number(b.poolStat?.pairedApr) - Number(a.poolStat?.pairedApr)
               );
             case "poolTvl":
               return Number(b.poolStat?.poolTVL) - Number(a.poolStat?.poolTVL);
             default:
-              return Number(b.poolStat?.poolApr) - Number(a.poolStat?.poolApr);
+              return (
+                Number(b.poolStat?.rewardApr) - Number(a.poolStat?.rewardApr)
+              );
           }
         })
         // Then sort by balance

--- a/app/src/views/PoolPage/usePoolPageData.tsx
+++ b/app/src/views/PoolPage/usePoolPageData.tsx
@@ -32,7 +32,6 @@ export type PoolPageColumnId =
   | "pairedApr"
   // | "marginapy"
   | "gainLoss"
-  | "rewardApr"
   | "poolTvl"
   | "userShare"
   | "userValue";

--- a/app/src/views/StatsPage/StatsPage.tsx
+++ b/app/src/views/StatsPage/StatsPage.tsx
@@ -17,7 +17,7 @@ export default defineComponent({
   props: {},
   setup() {
     const { res, statsRef, state } = useStatsPageData({
-      sortBy: "rewardApr",
+      sortBy: "pairedApr",
       sortDirection: "desc",
     } as StatsPageState);
 
@@ -183,7 +183,7 @@ export default defineComponent({
                             class="h-[12px] w-[12px] transition-all"
                             style={{
                               transform:
-                                state.sortDirection === "asc"
+                                state.sortDirection === "desc"
                                   ? "rotate(0deg)"
                                   : "rotate(180deg)",
                             }}
@@ -270,7 +270,7 @@ export default defineComponent({
                         ${prettyNumber(item.volume)}
                       </td>
                       <td class="text-mono text-right align-middle">
-                        {item.poolApr}%
+                        {item.rewardApr}%
                       </td>
                       <td class="text-mono text-right align-middle">
                         {item.pairedApr}%

--- a/app/src/views/StatsPage/useStatsPageData.ts
+++ b/app/src/views/StatsPage/useStatsPageData.ts
@@ -12,7 +12,6 @@ export type StatsPageState = {
     | "tvl"
     | "volume"
     | "arbitrage"
-    | "poolApr"
     | "rowanApr"
     | "pairedApr"
     | "marginApr";
@@ -44,9 +43,8 @@ export function useStatsPageData(initialState: StatsPageState) {
           tvl: pool.poolTVL,
           volume: pool.volume ?? 0,
           arbitrage: pool.arb == null ? null : pool.arb ?? 0,
-          poolApr: Number(pool.poolApr).toFixed(2),
           pairedApr: Number(pool.pairedApr).toFixed(1),
-          rewardApr: pool.rewardApr,
+          rewardApr: Number(pool.rewardApr).toFixed(2),
           marginApr: pool.margin_apr,
         };
 


### PR DESCRIPTION
`paired APR%` is now the default sorting option on both `Pool Stat` and `Pools` pages
<img width="972" alt="image" src="https://github.com/Sifchain/sifchain-ui/assets/4013866/5805f3d8-0bcc-4106-ae3d-07f65246c6e7">

<img width="927" alt="image" src="https://github.com/Sifchain/sifchain-ui/assets/4013866/2076d979-fb6d-4e52-9dc6-1ce81ee493b9">
