### PR TITLE
Fix/cleanup

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "2.14.31",
+  "version": "2.14.32",
   "private": true,
   "scripts": {
     "bump": "bump patch --tag --commit 'testnet release '",

--- a/app/src/components/NavSidePanel/NavSidePanel.tsx
+++ b/app/src/components/NavSidePanel/NavSidePanel.tsx
@@ -160,7 +160,10 @@ export default defineComponent({
                 <NavSidePanelItem
                   displayName="Charts"
                   icon="navigation/charts"
-                  href="https://dexscreener.com/sifchain/cusdc"
+                  href=""
+                  class="opacity-50"
+                  style="pointer-events: none;"
+                  // href="https://dexscreener.com/sifchain/cusdc"
                 />
                 <NavSidePanelItem
                   icon="navigation/changelog"
@@ -203,7 +206,10 @@ export default defineComponent({
                     <NavSidePanelItem
                       displayName="Rowan Faucet"
                       icon="navigation/rowan"
-                      href="https://stakely.io/faucet/sifchain-rowan"
+                      // href="https://stakely.io/faucet/sifchain-rowan"
+                      href=""
+                      class="opacity-50"
+                      style="pointer-events: none;"
                     />
                   )}
                 <Tooltip

--- a/app/src/views/PoolPage/PoolPage.tsx
+++ b/app/src/views/PoolPage/PoolPage.tsx
@@ -32,7 +32,7 @@ export default defineComponent({
       sortBy: "pairedApr" as PoolPageColumnId,
       sortReverse: false,
       searchQuery: "",
-      showSmallPools: true,
+      showSmallPools: false,
     };
   },
   setup() {

--- a/app/src/views/StatsPage/StatsPage.tsx
+++ b/app/src/views/StatsPage/StatsPage.tsx
@@ -108,7 +108,7 @@ export default defineComponent({
 
     const searchQuery = ref("");
 
-    const showSmallPools = ref(true);
+    const showSmallPools = ref(false);
 
     const finalStats = computed(() => {
       return statsRef.value.filter((item) => {


### PR DESCRIPTION
Cleanup:
* do not show small pools (below $10k) by default on `Pool Stats` and `Pool` pages
* Make non-working navigation items inactive: `Charts`, `Faucet`

<img width="553" alt="Screenshot 2024-01-16 at 23 21 53" src="https://github.com/Sifchain/sifchain-ui/assets/4013866/757b3975-89a6-4391-8932-fa409a6b310e">
<img width="944" alt="Screenshot 2024-01-16 at 23 23 18" src="https://github.com/Sifchain/sifchain-ui/assets/4013866/7d1af867-74f6-40e4-90f9-eb3209310ba2">
<img width="969" alt="Screenshot 2024-01-16 at 23 22 27" src="https://github.com/Sifchain/sifchain-ui/assets/4013866/f7a74146-da63-445c-8010-f5fdcb283dc4">
